### PR TITLE
feat(redis): Adds the redis cluster

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     paths:
-      - "config/terraform/aws/*"
+      - "server/aws/*"
       - ".github/workflows/*"
 
 defaults:

--- a/server/aws/elasticache.tf
+++ b/server/aws/elasticache.tf
@@ -1,10 +1,6 @@
 resource "aws_elasticache_subnet_group" "covidshield" {
   name       = "covidshield"
   subnet_ids = aws_subnet.covidshield_private.*.id
-
-  tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-  }
 }
 
 resource "aws_elasticache_replication_group" "covidshield" {

--- a/server/aws/elasticache.tf
+++ b/server/aws/elasticache.tf
@@ -1,0 +1,28 @@
+resource "aws_elasticache_subnet_group" "covidshield" {
+  name       = "covidshield"
+  subnet_ids = aws_subnet.covidshield_private.*.id
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
+resource "aws_elasticache_replication_group" "covidshield" {
+  automatic_failover_enabled    = true
+  availability_zones            = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], data.aws_availability_zones.available.names[2]]
+  replication_group_id          = "covidshield"
+  replication_group_description = "covidshield"
+  node_type                     = "cache.t2.small"
+  number_cache_clusters         = 3
+  parameter_group_name          = "default.redis5.0"
+  security_group_ids            = [aws_security_group.covidshield_redis.id]
+  subnet_group_name             = aws_elasticache_subnet_group.covidshield.name
+  apply_immediately             = true
+  port                          = 6379
+  at_rest_encryption_enabled    = true
+  transit_encryption_enabled    = true
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}

--- a/server/aws/networking.tf
+++ b/server/aws/networking.tf
@@ -232,6 +232,16 @@ resource "aws_security_group_rule" "covidshield_key_retrieval_egress_database" {
   source_security_group_id = aws_security_group.covidshield_database.id
 }
 
+resource "aws_security_group_rule" "covidshield_key_retrieval_egress_redis" {
+  description              = "Security group rule for Retrieval Redis egress through privatelink"
+  type                     = "egress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.covidshield_key_retrieval.id
+  source_security_group_id = aws_security_group.covidshield_redis.id
+}
+
 resource "aws_security_group" "covidshield_key_submission" {
   name        = "covidshield-key-submission"
   description = "Ingress - CovidShield Key Submission App"
@@ -282,6 +292,16 @@ resource "aws_security_group_rule" "covidshield_key_submission_egress_database" 
   protocol                 = "tcp"
   security_group_id        = aws_security_group.covidshield_key_submission.id
   source_security_group_id = aws_security_group.covidshield_database.id
+}
+
+resource "aws_security_group_rule" "covidshield_key_submission_egress_redis" {
+  description              = "Security group rule for Submission Redis egress through privatelink"
+  type                     = "egress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.covidshield_key_submission.id
+  source_security_group_id = aws_security_group.covidshield_redis.id
 }
 
 resource "aws_security_group" "covidshield_load_balancer" {
@@ -348,6 +368,26 @@ resource "aws_security_group" "covidshield_database" {
     protocol  = "tcp"
     from_port = 3306
     to_port   = 3306
+    security_groups = [
+      aws_security_group.covidshield_key_retrieval.id,
+      aws_security_group.covidshield_key_submission.id
+    ]
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
+resource "aws_security_group" "covidshield_redis" {
+  name        = "covidshield-redis"
+  description = "Ingress - CovidShield Redis"
+  vpc_id      = aws_vpc.covidshield.id
+
+  ingress {
+    protocol  = "tcp"
+    from_port = 6379
+    to_port   = 6379
     security_groups = [
       aws_security_group.covidshield_key_retrieval.id,
       aws_security_group.covidshield_key_submission.id


### PR DESCRIPTION
This PR adds an elasticache (Redis) cluster to the infrastructure. It uses the existing private subnet that is used by the DB and fargate instances to communicate. It sets up a security group that allows communication between the redis cluster and the containers. It also has 3 replicas, one for each security group.