### PR TITLE
feat(redis): Make REDIS_URL available to containers

### DIFF
--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -37,6 +37,7 @@ data "template_file" "covidshield_key_retrieval_task" {
     retrieve_hmac_key     = aws_secretsmanager_secret_version.key_retrieval_env_hmac_key.arn
     ecdsa_key             = aws_secretsmanager_secret_version.key_retrieval_env_ecdsa_key.arn
     database_url          = aws_secretsmanager_secret_version.server_database_url.arn
+    redis_url             = aws_secretsmanager_secret_version.server_redis_url.arn
     metric_provider       = var.metric_provider
     tracer_provider       = var.tracer_provider
     env                   = var.environment
@@ -170,6 +171,7 @@ data "template_file" "covidshield_key_submission_task" {
     awslogs-stream-prefix = "ecs-${var.ecs_key_submission_name}"
     key_claim_token       = aws_secretsmanager_secret_version.key_submission_env_key_claim_token.arn
     database_url          = aws_secretsmanager_secret_version.server_database_url.arn
+    redis_url             = aws_secretsmanager_secret_version.server_redis_url.arn
     metric_provider       = var.metric_provider
     tracer_provider       = var.tracer_provider
     env                   = var.environment

--- a/server/aws/secrets.tf
+++ b/server/aws/secrets.tf
@@ -17,7 +17,7 @@ resource "aws_secretsmanager_secret" "server_redis_url" {
 
 resource "aws_secretsmanager_secret_version" "server_redis_url" {
   secret_id     = aws_secretsmanager_secret.server_redis_url.id
-  secret_string = "redis://${aws_elasticache_replication_group.covidshield.configuration_endpoint_address}:${aws_elasticache_replication_group.covidshield.port}"
+  secret_string = "redis://${aws_elasticache_replication_group.covidshield.primary_endpoint_address}:${aws_elasticache_replication_group.covidshield.port}"
 }
 
 ###

--- a/server/aws/secrets.tf
+++ b/server/aws/secrets.tf
@@ -1,3 +1,7 @@
+###
+# AWS Secret Manager - Storage
+###
+
 resource "aws_secretsmanager_secret" "server_database_url" {
   name = "server-database-url-${random_string.random.result}"
 }
@@ -5,6 +9,15 @@ resource "aws_secretsmanager_secret" "server_database_url" {
 resource "aws_secretsmanager_secret_version" "server_database_url" {
   secret_id     = aws_secretsmanager_secret.server_database_url.id
   secret_string = "${var.rds_server_db_user}:${var.rds_server_db_password}@tcp(${aws_rds_cluster.covidshield_server.endpoint})/${var.rds_server_db_name}"
+}
+
+resource "aws_secretsmanager_secret" "server_redis_url" {
+  name = "server-redis-url-${random_string.random.result}"
+}
+
+resource "aws_secretsmanager_secret_version" "server_redis_url" {
+  secret_id     = aws_secretsmanager_secret.server_redis_url.id
+  secret_string = "redis://${aws_elasticache_replication_group.covidshield.configuration_endpoint_address}:${aws_elasticache_replication_group.covidshield.port}"
 }
 
 ###

--- a/server/aws/task-definitions/covidshield_key_retrieval.json
+++ b/server/aws/task-definitions/covidshield_key_retrieval.json
@@ -46,6 +46,10 @@
         {
           "name": "DATABASE_URL",
           "valueFrom": "${database_url}"
+        },
+        {
+          "name": "REDIS_URL",
+          "valueFrom": "${redis_url}"
         }
       ]
     }

--- a/server/aws/task-definitions/covidshield_key_submission.json
+++ b/server/aws/task-definitions/covidshield_key_submission.json
@@ -49,6 +49,10 @@
         {
           "name": "DATABASE_URL",
           "valueFrom": "${database_url}"
+        },
+        {
+          "name": "REDIS_URL",
+          "valueFrom": "${redis_url}"
         }
       ]
     }


### PR DESCRIPTION
Allows the Fargate containers to access the Redis cluster by providing the connection string through the `REDIS_URL` environment variable. This is managed as a computed secret in Terraform, similar to how we construct the MySQL connection string.