### PR TITLE
feat: Add CORS to S3 bucket and pass through cloudfront

### DIFF
--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -64,13 +64,13 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
 
   ordered_cache_behavior {
     path_pattern     = "/exposure-configuration/*"
-    allowed_methods  = ["GET", "HEAD"]
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "covid-shield-exposure-config-${var.environment}"
 
     forwarded_values {
       query_string = false
-      headers      = ["Origin"]
+      headers      = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
 
       cookies {
         forward = "none"

--- a/server/aws/s3.tf
+++ b/server/aws/s3.tf
@@ -12,6 +12,13 @@ resource "aws_s3_bucket" "exposure_config" {
     }
   }
 
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+  }
+
   logging {
     target_bucket = aws_s3_bucket.exposure_config_logs.bucket
   }


### PR DESCRIPTION
The mobile app requires a pre-flight check for CORS to access the items in the exposure-configuration S3 bucket. This PR adds the CORS options to the S3 bucket and also configures cloudfront to pass those headers and values back out.
