### PR TITLE
fix(event): Expose key claim token to Retrieval service

### DIFF
--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -35,6 +35,7 @@ data "template_file" "covidshield_key_retrieval_task" {
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_retrieval_name}"
     retrieve_hmac_key     = aws_secretsmanager_secret_version.key_retrieval_env_hmac_key.arn
+    key_claim_token       = aws_secretsmanager_secret_version.key_submission_env_key_claim_token.arn
     ecdsa_key             = aws_secretsmanager_secret_version.key_retrieval_env_ecdsa_key.arn
     database_url          = aws_secretsmanager_secret_version.server_database_url.arn
     metric_provider       = var.metric_provider

--- a/server/aws/task-definitions/covidshield_key_retrieval.json
+++ b/server/aws/task-definitions/covidshield_key_retrieval.json
@@ -36,6 +36,10 @@
       ],
       "secrets": [
         {
+          "name": "KEY_CLAIM_TOKEN",
+          "valueFrom": "${key_claim_token}"
+        },
+        {
           "name": "RETRIEVE_HMAC_KEY",
           "valueFrom": "${retrieve_hmac_key}"
         },


### PR DESCRIPTION
Exposes the Key Claim Token to the retrieval service so it's able to translate tokens.
