### PR TITLE
fix(event): Allow retrieval server to read the secret

### DIFF
--- a/server/aws/iam.tf
+++ b/server/aws/iam.tf
@@ -22,6 +22,7 @@ data "aws_iam_policy_document" "covidshield_secrets_manager_key_retrieval" {
     ]
 
     resources = [
+      aws_secretsmanager_secret.key_submission_env_key_claim_token.arn,
       aws_secretsmanager_secret.key_retrieval_env_hmac_key.arn,
       aws_secretsmanager_secret.key_retrieval_env_ecdsa_key.arn,
       aws_secretsmanager_secret.server_database_url.arn,


### PR DESCRIPTION
Allows the Key-Retrieval server to read the Secret storing the bearer tokens.