### PR TITLE
fix: Save metrics password to secret manager

### DIFF
--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -175,7 +175,7 @@ data "template_file" "covidshield_key_submission_task" {
     tracer_provider       = var.tracer_provider
     env                   = var.environment
     metrics_username      = var.metrics_username
-    metrics_password      = var.metrics_password
+    metrics_password      = aws_secretsmanager_secret_version.key_submission_metrics_password.arn
   }
 }
 

--- a/server/aws/iam.tf
+++ b/server/aws/iam.tf
@@ -72,6 +72,7 @@ data "aws_iam_policy_document" "covidshield_secrets_manager_key_submission" {
     resources = [
       aws_secretsmanager_secret.key_submission_env_key_claim_token.arn,
       aws_secretsmanager_secret.server_database_url.arn,
+      aws_secretsmanager_secret.key_submission_metrics_password.arn
     ]
   }
 }

--- a/server/aws/secrets.tf
+++ b/server/aws/secrets.tf
@@ -43,11 +43,11 @@ resource "aws_secretsmanager_secret_version" "key_submission_env_key_claim_token
 }
 
 
-resource "aws_secretsmanager_secret" "key_submission_metric_password" {
+resource "aws_secretsmanager_secret" "key_submission_metrics_password" {
   name = "key-metric-password-${random_string.random.result}"
 }
 
-resource "aws_secretsmanager_secret_version" "key_submission_metric_password" {
-  secret_id     = aws_secretsmanager_secret.key_submission_metric_password.id
+resource "aws_secretsmanager_secret_version" "key_submission_metrics_password" {
+  secret_id     = aws_secretsmanager_secret.key_submission_metrics_password.id
   secret_string = var.metrics_password
 }

--- a/server/aws/secrets.tf
+++ b/server/aws/secrets.tf
@@ -41,3 +41,13 @@ resource "aws_secretsmanager_secret_version" "key_submission_env_key_claim_token
   secret_id     = aws_secretsmanager_secret.key_submission_env_key_claim_token.id
   secret_string = var.ecs_task_key_submission_env_key_claim_token
 }
+
+
+resource "aws_secretsmanager_secret" "key_submission_metric_password" {
+  name = "key-metric-password-${random_string.random.result}"
+}
+
+resource "aws_secretsmanager_secret_version" "key_submission_metric_password" {
+  secret_id     = aws_secretsmanager_secret.key_submission_metric_password.id
+  secret_string = var.metrics_password
+}


### PR DESCRIPTION
Adds Metrics Password to Secrets Manager
Adds Metrics Password ARN to Key-Submission IAM
Adds arn to ECS TF instead of passing the password as plain text
