### PR TITLE
scaling down to t3 to save money.

### DIFF
--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -58,7 +58,7 @@ rds_server_db_user = "root"
 # Value should come from a TF_VAR environment variable (e.g. set in a Github Secret)
 # rds_server_db_password       = ""
 rds_server_allocated_storage = "5"
-rds_server_instance_class    = "db.r5.large"
+rds_server_instance_class    = "db.t3.medium"
 
 ###
 # AWS Route 53 - route53.tf


### PR DESCRIPTION
This is their standard instance current generation burstable 

Price difference can be seen here: 
https://aws.amazon.com/rds/pricing/

Available options are here:
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.html


