### PR TITLE
feat: moving events from sub to ret

### DIFF
--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -88,13 +88,14 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     path_pattern     = "/events/*"
     allowed_methods  = ["GET"]
     cached_methods   = []
-    target_origin_id = "covid-shield-exposure-config-${var.environment}"
+    target_origin_id = aws_lb.covidshield_key_retrieval.name
 
     forwarded_values {
-      headers      = ["*"]
-      query_string = false
+      query_string = true
+      headers      = ["Host"]
+
       cookies {
-        forward = "none"
+        forward = "all"
       }
     }
 

--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -84,6 +84,19 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     compress               = true
   }
 
+  ordered_cache_behavior {  // We don't want to cache the events endpoint just pass through 
+    path_pattern = "/events/*"
+    allowed_methods = ["GET"]
+    cached_methods = []
+    target_origin_id = "covid-shield-exposure-config-${var.environment}"
+
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 0
+    max_ttl                = 0
+    compress               = true
+
+  }
+
 
   price_class = "PriceClass_100"
 

--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -84,10 +84,10 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     compress               = true
   }
 
-  ordered_cache_behavior {  // We don't want to cache the events endpoint just pass through 
-    path_pattern = "/events/*"
-    allowed_methods = ["GET"]
-    cached_methods = []
+  ordered_cache_behavior { // We don't want to cache the events endpoint just pass through 
+    path_pattern     = "/events/*"
+    allowed_methods  = ["GET"]
+    cached_methods   = []
     target_origin_id = "covid-shield-exposure-config-${var.environment}"
 
     viewer_protocol_policy = "https-only"

--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -90,6 +90,14 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     cached_methods   = []
     target_origin_id = "covid-shield-exposure-config-${var.environment}"
 
+    forwarded_values {
+      headers      = ["*"]
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
     viewer_protocol_policy = "https-only"
     min_ttl                = 0
     max_ttl                = 0

--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -41,6 +41,8 @@ data "template_file" "covidshield_key_retrieval_task" {
     metric_provider       = var.metric_provider
     tracer_provider       = var.tracer_provider
     env                   = var.environment
+    metrics_username      = var.metrics_username
+    metrics_password      = aws_secretsmanager_secret_version.key_retrieval_metrics_password.arn
   }
 }
 
@@ -174,8 +176,6 @@ data "template_file" "covidshield_key_submission_task" {
     metric_provider       = var.metric_provider
     tracer_provider       = var.tracer_provider
     env                   = var.environment
-    metrics_username      = var.metrics_username
-    metrics_password      = aws_secretsmanager_secret_version.key_submission_metrics_password.arn
   }
 }
 

--- a/server/aws/iam.tf
+++ b/server/aws/iam.tf
@@ -26,6 +26,7 @@ data "aws_iam_policy_document" "covidshield_secrets_manager_key_retrieval" {
       aws_secretsmanager_secret.key_retrieval_env_hmac_key.arn,
       aws_secretsmanager_secret.key_retrieval_env_ecdsa_key.arn,
       aws_secretsmanager_secret.server_database_url.arn,
+      aws_secretsmanager_secret.key_retrieval_metrics_password.arn
     ]
   }
 }
@@ -71,8 +72,7 @@ data "aws_iam_policy_document" "covidshield_secrets_manager_key_submission" {
 
     resources = [
       aws_secretsmanager_secret.key_submission_env_key_claim_token.arn,
-      aws_secretsmanager_secret.server_database_url.arn,
-      aws_secretsmanager_secret.key_submission_metrics_password.arn
+      aws_secretsmanager_secret.server_database_url.arn
     ]
   }
 }

--- a/server/aws/secrets.tf
+++ b/server/aws/secrets.tf
@@ -43,11 +43,11 @@ resource "aws_secretsmanager_secret_version" "key_submission_env_key_claim_token
 }
 
 
-resource "aws_secretsmanager_secret" "key_submission_metrics_password" {
+resource "aws_secretsmanager_secret" "key_retrieval_metrics_password" {
   name = "key-metric-password-${random_string.random.result}"
 }
 
-resource "aws_secretsmanager_secret_version" "key_submission_metrics_password" {
-  secret_id     = aws_secretsmanager_secret.key_submission_metrics_password.id
+resource "aws_secretsmanager_secret_version" "key_retrieval_metrics_password" {
+  secret_id     = aws_secretsmanager_secret.key_retrieval_metrics_password.id
   secret_string = var.metrics_password
 }

--- a/server/aws/task-definitions/covidshield_key_retrieval.json
+++ b/server/aws/task-definitions/covidshield_key_retrieval.json
@@ -50,6 +50,10 @@
         {
           "name": "DATABASE_URL",
           "valueFrom": "${database_url}"
+        },
+        {
+          "name": "METRICS_PASSWORD",
+          "valueFrom": "${metrics_password}"
         }
       ]
     }

--- a/server/aws/task-definitions/covidshield_key_retrieval.json
+++ b/server/aws/task-definitions/covidshield_key_retrieval.json
@@ -32,6 +32,10 @@
         {
           "name": "ENV",
           "value": "${env}"
+        },
+        {
+          "name": "METRICS_USERNAME",
+          "value": "${metrics_username}"
         }
       ],
       "secrets": [

--- a/server/aws/task-definitions/covidshield_key_submission.json
+++ b/server/aws/task-definitions/covidshield_key_submission.json
@@ -53,10 +53,6 @@
         {
           "name": "DATABASE_URL",
           "valueFrom": "${database_url}"
-        },
-        {
-          "name": "METRICS_PASSWORD",
-          "valueFrom": "${metrics_password}"
         }
       ]
     }

--- a/server/aws/task-definitions/covidshield_key_submission.json
+++ b/server/aws/task-definitions/covidshield_key_submission.json
@@ -39,10 +39,6 @@
         {
           "name": "ENV",
           "value": "${env}"
-        },
-        {
-          "name": "METRICS_USERNAME",
-          "value": "${metrics_username}"
         }
       ],
       "secrets": [


### PR DESCRIPTION
Due to the requirement to vastly increase the number of IPs that need to be safelisted for event automation I've decided to move the events endpoint from the submission to the retrieval server. 

This PR needs to occur before the covid-alert-server pr occurs.
https://github.com/cds-snc/covid-alert-server/pull/321