### PR TITLE
fix: add HEAD for CF and fix name of secret

### DIFF
--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -86,7 +86,7 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
 
   ordered_cache_behavior { // We don't want to cache the events endpoint just pass through 
     path_pattern     = "/events/*"
-    allowed_methods  = ["GET"]
+    allowed_methods  = ["GET", "HEAD"]
     cached_methods   = []
     target_origin_id = aws_lb.covidshield_key_retrieval.name
 

--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -42,7 +42,7 @@ data "template_file" "covidshield_key_retrieval_task" {
     tracer_provider       = var.tracer_provider
     env                   = var.environment
     metrics_username      = var.metrics_username
-    metrics_password      = aws_secretsmanager_secret_version.key_retrieval_metrics_password.arn
+    metrics_password      = aws_secretsmanager_secret_version.key_submission_metrics_password.arn
   }
 }
 

--- a/server/aws/iam.tf
+++ b/server/aws/iam.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "covidshield_secrets_manager_key_retrieval" {
       aws_secretsmanager_secret.key_retrieval_env_hmac_key.arn,
       aws_secretsmanager_secret.key_retrieval_env_ecdsa_key.arn,
       aws_secretsmanager_secret.server_database_url.arn,
-      aws_secretsmanager_secret.key_retrieval_metrics_password.arn
+      aws_secretsmanager_secret.key_submission_metrics_password.arn
     ]
   }
 }

--- a/server/aws/secrets.tf
+++ b/server/aws/secrets.tf
@@ -43,11 +43,11 @@ resource "aws_secretsmanager_secret_version" "key_submission_env_key_claim_token
 }
 
 
-resource "aws_secretsmanager_secret" "key_retrieval_metrics_password" {
+resource "aws_secretsmanager_secret" "key_submission_metrics_password" {
   name = "key-metric-password-${random_string.random.result}"
 }
 
-resource "aws_secretsmanager_secret_version" "key_retrieval_metrics_password" {
-  secret_id     = aws_secretsmanager_secret.key_retrieval_metrics_password.id
+resource "aws_secretsmanager_secret_version" "key_submission_metrics_password" {
+  secret_id     = aws_secretsmanager_secret.key_submission_metrics_password.id
   secret_string = var.metrics_password
 }


### PR DESCRIPTION
Fixes the references to the secret, we cannot just rename TF resources
Fixes the issue with the cloudfront forwarding not having the HEAD verb
