### PR TITLE
fix: add cached headers

### DIFF
--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -87,7 +87,7 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
   ordered_cache_behavior { // We don't want to cache the events endpoint just pass through 
     path_pattern     = "/events/*"
     allowed_methods  = ["GET", "HEAD"]
-    cached_methods   = []
+    cached_methods   = ["GET", "HEAD"]
     target_origin_id = aws_lb.covidshield_key_retrieval.name
 
     forwarded_values {


### PR DESCRIPTION
Added get and head to cache headers, hopefully the fact that TTL is 0 this shouldn't cache
