### PR TITLE
fix: fwd auth header, add default_ttl = 0

### DIFF
--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -92,7 +92,7 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
 
     forwarded_values {
       query_string = true
-      headers      = ["Host"]
+      headers      = ["Host", "Authorization"]
 
       cookies {
         forward = "all"
@@ -101,6 +101,7 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
 
     viewer_protocol_policy = "https-only"
     min_ttl                = 0
+    default_ttl            = 0
     max_ttl                = 0
     compress               = true
 


### PR DESCRIPTION
Forwards the auth header as cloud front stripped it out
Add a default TTL of 0 so it never caches
