### PR TITLE
feat/aws tf upgrade

### DIFF
--- a/server/aws/bootstrap/provider.tf
+++ b/server/aws/bootstrap/provider.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "storage_bucket" {
   bucket = var.storage_bucket
   acl    = "private"
   logging {
-    target_bucket = "${aws_s3_bucket.log_bucket.id}"
+    target_bucket = aws_s3_bucket.log_bucket.id
     target_prefix = "log/"
   }
   server_side_encryption_configuration {

--- a/server/aws/certificates.tf
+++ b/server/aws/certificates.tf
@@ -31,31 +31,48 @@ resource "aws_acm_certificate" "retrieval_covidshield" {
 
 resource "aws_route53_record" "covidshield_certificate_validation" {
   zone_id = aws_route53_zone.covidshield.zone_id
-  name    = aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_type
-  records = [aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_value]
-  ttl     = 60
+
+  for_each = {
+    for dvo in aws_acm_certificate.covidshield.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  type    = each.value.type
+
+  ttl = 60
 }
 
 resource "aws_route53_record" "retrieval_covidshield_certificate_validation" {
   zone_id = aws_route53_zone.covidshield.zone_id
-  name    = aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_type
-  records = [aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_value]
-  ttl     = 60
+
+  for_each = {
+    for dvo in aws_acm_certificate.retrieval_covidshield.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  type    = each.value.type
+
+  ttl = 60
 }
 
 resource "aws_acm_certificate_validation" "covidshield" {
-  certificate_arn = aws_acm_certificate.covidshield.arn
-  validation_record_fqdns = [
-    aws_route53_record.covidshield_certificate_validation.fqdn
-  ]
+  certificate_arn         = aws_acm_certificate.covidshield.arn
+  validation_record_fqdns = [for record in aws_route53_record.covidshield_certificate_validation : record.fqdn]
 }
 
 resource "aws_acm_certificate_validation" "retrieval_covidshield" {
-  provider        = aws.us-east-1
-  certificate_arn = aws_acm_certificate.retrieval_covidshield.arn
-  validation_record_fqdns = [
-    aws_route53_record.retrieval_covidshield_certificate_validation.fqdn
-  ]
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.retrieval_covidshield.arn
+  validation_record_fqdns = [for record in aws_route53_record.retrieval_covidshield_certificate_validation : record.fqdn]
 }

--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -30,7 +30,7 @@ data "template_file" "covidshield_key_retrieval_task" {
   template = file("task-definitions/covidshield_key_retrieval.json")
 
   vars = {
-    image                 = "${local.retrieval_repo}"
+    image                 = local.retrieval_repo
     awslogs-group         = aws_cloudwatch_log_group.covidshield.name
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_retrieval_name}"
@@ -167,7 +167,7 @@ data "template_file" "covidshield_key_submission_task" {
   template = file("task-definitions/covidshield_key_submission.json")
 
   vars = {
-    image                 = "${local.submission_repo}"
+    image                 = local.submission_repo
     awslogs-group         = aws_cloudwatch_log_group.covidshield.name
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_submission_name}"

--- a/server/aws/networking.tf
+++ b/server/aws/networking.tf
@@ -26,7 +26,7 @@ resource "aws_vpc_endpoint" "ecr-dkr" {
   service_name        = "com.amazonaws.${var.region}.ecr.dkr"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = data.aws_subnet_ids.ecr_endpoint_available.ids
 }
@@ -37,7 +37,7 @@ resource "aws_vpc_endpoint" "ecr-api" {
   service_name        = "com.amazonaws.${var.region}.ecr.api"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = data.aws_subnet_ids.ecr_endpoint_available.ids
 }
@@ -48,7 +48,7 @@ resource "aws_vpc_endpoint" "kms" {
   service_name        = "com.amazonaws.${var.region}.kms"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = aws_subnet.covidshield_private.*.id
 }
@@ -59,7 +59,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   service_name        = "com.amazonaws.${var.region}.secretsmanager"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = aws_subnet.covidshield_private.*.id
 }
@@ -77,7 +77,7 @@ resource "aws_vpc_endpoint" "logs" {
   service_name        = "com.amazonaws.${var.region}.logs"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = aws_subnet.covidshield_private.*.id
 }
@@ -88,7 +88,7 @@ resource "aws_vpc_endpoint" "monitoring" {
   service_name        = "com.amazonaws.${var.region}.monitoring"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = aws_subnet.covidshield_private.*.id
 }

--- a/server/aws/provider.tf
+++ b/server/aws/provider.tf
@@ -1,16 +1,16 @@
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.11"
   region  = var.region
 }
 
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.11"
   alias   = "us-east-1"
   region  = "us-east-1"
 }
 
 terraform {
-  required_version = "> 0.12.0"
+  required_version = "> 0.13.4"
 }
 
 terraform {

--- a/server/aws/provider.tf
+++ b/server/aws/provider.tf
@@ -10,7 +10,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "> 0.13.4"
+  required_version = "= 0.13.4"
 }
 
 terraform {

--- a/server/aws/waf.tf
+++ b/server/aws/waf.tf
@@ -581,7 +581,7 @@ resource "aws_wafv2_web_acl_association" "key_retrieval_assocation" {
 # AWS WAF - Logging
 ###
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs" {
-  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn]
   resource_arn            = aws_wafv2_web_acl.key_submission.arn
   redacted_fields {
     single_header {
@@ -591,13 +591,13 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval" {
-  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn]
   resource_arn            = aws_wafv2_web_acl.key_retrieval.arn
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval_cdn" {
   provider = aws.us-east-1
 
-  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs_us_east.arn}"]
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs_us_east.arn]
   resource_arn            = aws_wafv2_web_acl.key_retrieval_cdn.arn
 }


### PR DESCRIPTION
- feat: Upgrading to tf 0.12 interpolation
- feat: Upgrade AWS Provider and Terraform Version
- feat: Pin the Terraform Version to greater then v0.13.4 
- feat: Pin the AWS Provider to 3.11 or greater which is the current version of
the provider.

Due to how ACM validation works in the new version of the provider we
had to modify that resource so it no longer access the first item in the
Domain_Validation_Options property but iterates through all
possibilities.

This means there will be a new ACM Validation Resource created for
wild-samphire.cdssandbox.xyz alongside the Validation Resource for
*.wild-samphire.cdssandbox.xyz.

In order to prevent the application of these state files from deleting
and creating the existing ACM Validation Resources I had to manually run
the following two commands:

```bash
terraform state mv 'aws_route53_record.covidshield_certificate_validation' 'aws_route53_record.covidshield_certificate_validation["*.wild-samphire.cdssandbox.xyz"]'
terraform state mv 'aws_route53_record.retrieval_covidshield_certificate_validation' 'aws_route53_record.retrieval_covidshield_certificate_validation["retrieval.wild-samphire.cdssandbox.xyz"]'
```

*Please Note:* These should be the same commands in all environments
(with different URI's) but you should double check by running `terraform
plan` locally and viewing what resources will be created and destroyed
and work from there.

This closes #41 and also closes cds-snc/covid-alert-server#262