### PR TITLE
fix: Add allow_overwrite = true

### DIFF
--- a/server/aws/certificates.tf
+++ b/server/aws/certificates.tf
@@ -40,6 +40,7 @@ resource "aws_route53_record" "covidshield_certificate_validation" {
     }
   }
 
+  allow_overwrite = true
   name    = each.value.name
   records = [each.value.record]
   type    = each.value.type

--- a/server/aws/certificates.tf
+++ b/server/aws/certificates.tf
@@ -41,9 +41,9 @@ resource "aws_route53_record" "covidshield_certificate_validation" {
   }
 
   allow_overwrite = true
-  name    = each.value.name
-  records = [each.value.record]
-  type    = each.value.type
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
 
   ttl = 60
 }


### PR DESCRIPTION
Attempt to fix the issue with TF Apply complaining about a validation
already existing by removing the existing record from TF State and
allowing it to overwrite the existing validation rule:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_acm_certificate

>In larger or more complex environments though, this process can be tedius to match the old resource address to the new resource address and run all the necessary terraform state mv commands. Instead, since the aws_route53_record resource implements the allow_overwrite = true argument, it is possible to just remove the old aws_route53_record resources from the Terraform state using the terraform state rm command. In this case, Terraform will leave the existing records in Route 53 and plan to just overwrite the existing validation records with the same exact (previous) values.

Fixes:

## Description of what your PR accomplishes:

## Why this approach? Any notable design decisions?

## Anything the reviewers should focus on? Any discussion points?
