### PR TITLE
feat: Add enable_test_tools flag to retrieval svc

### DIFF
--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -43,6 +43,7 @@ data "template_file" "covidshield_key_retrieval_task" {
     env                   = var.environment
     metrics_username      = var.metrics_username
     metrics_password      = aws_secretsmanager_secret_version.key_submission_metrics_password.arn
+    enable_test_tools     = var.enable_test_tools
   }
 }
 

--- a/server/aws/task-definitions/covidshield_key_retrieval.json
+++ b/server/aws/task-definitions/covidshield_key_retrieval.json
@@ -36,6 +36,10 @@
         {
           "name": "METRICS_USERNAME",
           "value": "${metrics_username}"
+        },
+        {
+          "name": "ENABLE_TEST_TOOLS",
+          "value": "${enable_test_tools}"
         }
       ],
       "secrets": [

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -87,4 +87,4 @@ claimed_one_time_code_total_critical = 4500
 unclaimed_one_time_code_total_warn     = 250
 unclaimed_one_time_code_total_critical = 400
 
-
+enable_test_tools = true

--- a/server/aws/variables.tf
+++ b/server/aws/variables.tf
@@ -199,3 +199,13 @@ variable "feature_redis" {
 variable "feature_shield" {
   type = bool
 }
+
+
+###
+# Testing Tools
+###
+
+variable "enable_test_tools" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
Add the ENABLE_TEST_TOOLS flag to staging to enable the endpoint that clears the diagnosis_keys table
