### PR TITLE
feat: Add WAF rule for clear keys URI

### DIFF
--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -43,7 +43,6 @@ data "template_file" "covidshield_key_retrieval_task" {
     env                   = var.environment
     metrics_username      = var.metrics_username
     metrics_password      = aws_secretsmanager_secret_version.key_submission_metrics_password.arn
-    enable_test_tools     = var.enable_test_tools
   }
 }
 
@@ -177,6 +176,7 @@ data "template_file" "covidshield_key_submission_task" {
     metric_provider       = var.metric_provider
     tracer_provider       = var.tracer_provider
     env                   = var.environment
+    enable_test_tools     = var.enable_test_tools
   }
 }
 

--- a/server/aws/task-definitions/covidshield_key_retrieval.json
+++ b/server/aws/task-definitions/covidshield_key_retrieval.json
@@ -36,10 +36,6 @@
         {
           "name": "METRICS_USERNAME",
           "value": "${metrics_username}"
-        },
-        {
-          "name": "ENABLE_TEST_TOOLS",
-          "value": "${enable_test_tools}"
         }
       ],
       "secrets": [

--- a/server/aws/task-definitions/covidshield_key_submission.json
+++ b/server/aws/task-definitions/covidshield_key_submission.json
@@ -39,6 +39,10 @@
         {
           "name": "ENV",
           "value": "${env}"
+        },
+        {
+          "name": "ENABLE_TEST_TOOLS",
+          "value": "${enable_test_tools}"
         }
       ],
       "secrets": [

--- a/server/aws/waf.tf
+++ b/server/aws/waf.tf
@@ -454,6 +454,63 @@ resource "aws_wafv2_web_acl" "key_submission" {
     }
   }
 
+  rule {
+    name     = "ClearKeysURI"
+    priority = 201
+
+    action {
+      allow {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          byte_match_statement {
+            positional_constraint = "STARTS_WITH"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/clear-diagnosis-keys"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+        statement {
+          byte_match_statement {
+            positional_constraint = "STARTS_WITH"
+            field_to_match {
+              single_header {
+                name = "authorization"
+              }
+            }
+            search_string = "Bearer"
+            text_transformation {
+              priority = 1
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          ip_set_reference_statement {
+            arn = aws_wafv2_ip_set.new_key_claim.arn
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "ClearKeysURI"
+      sampled_requests_enabled   = false
+    }
+  }
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }

--- a/server/aws/waf.tf
+++ b/server/aws/waf.tf
@@ -456,7 +456,7 @@ resource "aws_wafv2_web_acl" "key_submission" {
 
   rule {
     name     = "ClearKeysURI"
-    priority = 201
+    priority = 202
 
     action {
       allow {}


### PR DESCRIPTION
Adds a WAF rule similar to `new-key-claim` that allows the calling of `/clear-diagnosis-keys` from the safelisted IPs