### PR TITLE
feat: Scale down ECS Task Def's and Service

### DIFF
--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -48,8 +48,8 @@ data "template_file" "covidshield_key_retrieval_task" {
 
 resource "aws_ecs_task_definition" "covidshield_key_retrieval" {
   family       = var.ecs_key_retrieval_name
-  cpu          = 1024
-  memory       = "1024"
+  cpu          = var.cpu_units
+  memory       = var.memory
   network_mode = "awsvpc"
 
   requires_compatibilities = ["FARGATE"]
@@ -77,7 +77,7 @@ resource "aws_ecs_service" "covidshield_key_retrieval" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 1
+  desired_count                      = var.min_capacity
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
@@ -182,8 +182,8 @@ data "template_file" "covidshield_key_submission_task" {
 
 resource "aws_ecs_task_definition" "covidshield_key_submission" {
   family       = var.ecs_key_submission_name
-  cpu          = 1024
-  memory       = "1024"
+  cpu          = var.cpu_units
+  memory       = var.memory
   network_mode = "awsvpc"
 
   requires_compatibilities = ["FARGATE"]
@@ -211,7 +211,7 @@ resource "aws_ecs_service" "covidshield_key_submission" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 1
+  desired_count                      = var.min_capacity
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60

--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -48,8 +48,8 @@ data "template_file" "covidshield_key_retrieval_task" {
 
 resource "aws_ecs_task_definition" "covidshield_key_retrieval" {
   family       = var.ecs_key_retrieval_name
-  cpu          = 2048
-  memory       = "4096"
+  cpu          = 1024
+  memory       = "1024"
   network_mode = "awsvpc"
 
   requires_compatibilities = ["FARGATE"]
@@ -77,7 +77,7 @@ resource "aws_ecs_service" "covidshield_key_retrieval" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 3
+  desired_count                      = 1
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
@@ -182,8 +182,8 @@ data "template_file" "covidshield_key_submission_task" {
 
 resource "aws_ecs_task_definition" "covidshield_key_submission" {
   family       = var.ecs_key_submission_name
-  cpu          = 2048
-  memory       = "4096"
+  cpu          = 1024
+  memory       = "1024"
   network_mode = "awsvpc"
 
   requires_compatibilities = ["FARGATE"]
@@ -211,7 +211,7 @@ resource "aws_ecs_service" "covidshield_key_submission" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 3
+  desired_count                      = 1
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -38,6 +38,9 @@ ecs_key_submission_name = "KeySubmission"
 
 submission_autoscale_enabled = true
 retrieval_autoscale_enabled  = true
+min_capacity                 = 1
+cpu_units                    = 1024
+memory                       = 1024
 
 ###
 # AWS VPC - networking.tf

--- a/server/aws/variables.tf
+++ b/server/aws/variables.tf
@@ -65,6 +65,16 @@ variable "max_capacity" {
   default = 10
 }
 
+variable "cpu_units" {
+  type    = number
+  default = 2048
+}
+
+variable "memory" {
+  type    = number
+  default = 4096
+}
+
 # Task Key Retrieval
 variable "ecs_key_retrieval_name" {
   type = string


### PR DESCRIPTION
## Feature: 

Scale down the retrieval and submission ECS service and Task Defintions

Scale down the ECS service to only 1 fargate instance running at a time. 

Scale down to 1 CPU as we currently avg less than a percentage of CPU utiliziation in staging

Scale down to 1 gig of ram as we avg around 7mb of ram usage. 

**Please Note:** We can probably scale this service down even more however I want to slowly work at this so we aren't negatively affecting staging too much
