### PR TITLE
Feat: Scale down to half a virtual cpu

### DIFF
--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -39,7 +39,7 @@ ecs_key_submission_name = "KeySubmission"
 submission_autoscale_enabled = true
 retrieval_autoscale_enabled  = true
 min_capacity                 = 1
-cpu_units                    = 1024
+cpu_units                    = 512
 memory                       = 1024
 
 ###


### PR DESCRIPTION
Scale down to 0.5 vcpu and 1 gig of ram per fargate instance
