### PR TITLE
feat: remove autoscaling configs & reconcile CBS

### DIFF
--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -113,50 +113,6 @@ resource "aws_ecs_service" "covidshield_key_retrieval" {
 
 }
 
-resource "aws_appautoscaling_target" "retrieval" {
-  count              = var.retrieval_autoscale_enabled ? 1 : 0
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.covidshield_key_retrieval.cluster}/${aws_ecs_service.covidshield_key_retrieval.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = var.min_capacity
-  max_capacity       = var.max_capacity
-}
-resource "aws_appautoscaling_policy" "retrieval_cpu" {
-  count              = var.retrieval_autoscale_enabled ? 1 : 0
-  name               = "retrieval_cpu"
-  policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.covidshield_key_retrieval.cluster}/${aws_ecs_service.covidshield_key_retrieval.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
-
-  target_tracking_scaling_policy_configuration {
-    scale_in_cooldown  = var.scale_in_cooldown
-    scale_out_cooldown = var.scale_out_cooldown
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageCPUUtilization"
-    }
-    target_value = var.cpu_scale_metric
-  }
-}
-
-resource "aws_appautoscaling_policy" "retrieval_memory" {
-  count              = var.retrieval_autoscale_enabled ? 1 : 0
-  name               = "retrieval_memory"
-  policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.covidshield_key_retrieval.cluster}/${aws_ecs_service.covidshield_key_retrieval.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
-
-  target_tracking_scaling_policy_configuration {
-    scale_in_cooldown  = var.scale_in_cooldown
-    scale_out_cooldown = var.scale_out_cooldown
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
-    }
-    target_value = var.memory_scale_metric
-  }
-}
-
 ###
 # ECS - Key Submission
 ###
@@ -243,48 +199,5 @@ resource "aws_ecs_service" "covidshield_key_submission" {
       task_definition, # updated by codedeploy
       load_balancer    # updated by codedeploy
     ]
-  }
-}
-resource "aws_appautoscaling_target" "submission" {
-  count              = var.submission_autoscale_enabled ? 1 : 0
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.covidshield_key_submission.cluster}/${aws_ecs_service.covidshield_key_submission.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = var.min_capacity
-  max_capacity       = var.max_capacity
-}
-resource "aws_appautoscaling_policy" "submission_cpu" {
-  count              = var.submission_autoscale_enabled ? 1 : 0
-  name               = "submission_cpu"
-  policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.covidshield_key_submission.cluster}/${aws_ecs_service.covidshield_key_submission.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
-
-  target_tracking_scaling_policy_configuration {
-    scale_in_cooldown  = var.scale_in_cooldown
-    scale_out_cooldown = var.scale_out_cooldown
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageCPUUtilization"
-    }
-    target_value = var.cpu_scale_metric
-  }
-}
-
-resource "aws_appautoscaling_policy" "submission_memory" {
-  count              = var.submission_autoscale_enabled ? 1 : 0
-  name               = "submission_memory"
-  policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.covidshield_key_submission.cluster}/${aws_ecs_service.covidshield_key_submission.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
-
-  target_tracking_scaling_policy_configuration {
-    scale_in_cooldown  = var.scale_in_cooldown
-    scale_out_cooldown = var.scale_out_cooldown
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
-    }
-    target_value = var.memory_scale_metric
   }
 }

--- a/server/aws/lb.tf
+++ b/server/aws/lb.tf
@@ -57,6 +57,12 @@ resource "aws_lb" "covidshield_key_retrieval" {
   ]
   subnets = aws_subnet.covidshield_public.*.id
 
+  access_logs {
+      bucket  = "cbs-satellite-account-bucket005133826942"
+      enabled = true
+      prefix  = "005133826942/elb_logs_v2"
+  }
+
   tags = {
     Name                  = "covidshield-key-retrieval"
     (var.billing_tag_key) = var.billing_tag_value
@@ -174,7 +180,11 @@ resource "aws_lb" "covidshield_key_submission" {
     aws_security_group.covidshield_load_balancer.id
   ]
   subnets = aws_subnet.covidshield_public.*.id
-
+  access_logs {
+        bucket  = "cbs-satellite-account-bucket005133826942"
+        enabled = true
+        prefix  = "005133826942/elb_logs_v2"
+    }
   tags = {
     Name                  = "covidshield-key-submission"
     (var.billing_tag_key) = var.billing_tag_value

--- a/server/aws/lb.tf
+++ b/server/aws/lb.tf
@@ -58,9 +58,9 @@ resource "aws_lb" "covidshield_key_retrieval" {
   subnets = aws_subnet.covidshield_public.*.id
 
   access_logs {
-      bucket  = "cbs-satellite-account-bucket005133826942"
-      enabled = true
-      prefix  = "005133826942/elb_logs_v2"
+    bucket  = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
+    enabled = true
+    prefix  = "${data.aws_caller_identity.current.account_id}/elb_logs_v2"
   }
 
   tags = {
@@ -181,10 +181,10 @@ resource "aws_lb" "covidshield_key_submission" {
   ]
   subnets = aws_subnet.covidshield_public.*.id
   access_logs {
-        bucket  = "cbs-satellite-account-bucket005133826942"
-        enabled = true
-        prefix  = "005133826942/elb_logs_v2"
-    }
+    bucket  = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
+    enabled = true
+    prefix  = "${data.aws_caller_identity.current.account_id}/elb_logs_v2"
+  }
   tags = {
     Name                  = "covidshield-key-submission"
     (var.billing_tag_key) = var.billing_tag_value

--- a/server/aws/s3.tf
+++ b/server/aws/s3.tf
@@ -13,8 +13,8 @@ resource "aws_s3_bucket" "exposure_config" {
   }
 
   logging {
-    target_bucket = "cbs-satellite-account-bucket005133826942"
-    target_prefix = "005133826942/s3_access_logs/covid-shield-exposure-config-staging/" 
+    target_bucket = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
+    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/covid-shield-exposure-config-staging/"
   }
 
 }
@@ -61,8 +61,8 @@ resource "aws_s3_bucket" "firehose_waf_logs" {
   }
 
   logging {
-    target_bucket = "cbs-satellite-account-bucket005133826942"
-    target_prefix = "005133826942/s3_access_logs/covid-shield-staging-waf-logs/"
+    target_bucket = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
+    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/covid-shield-staging-waf-logs/"
   }
 }
 
@@ -86,10 +86,10 @@ resource "aws_s3_bucket" "cloudfront_logs" {
       days = 90
     }
   }
-  
+
   logging {
-    target_bucket = "cbs-satellite-account-bucket005133826942"
-    target_prefix = "005133826942/s3_access_logs/covid-shield-staging-cloudfront-logs/"
+    target_bucket = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
+    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/covid-shield-staging-cloudfront-logs/"
   }
 }
 

--- a/server/aws/s3.tf
+++ b/server/aws/s3.tf
@@ -13,8 +13,10 @@ resource "aws_s3_bucket" "exposure_config" {
   }
 
   logging {
-    target_bucket = aws_s3_bucket.exposure_config_logs.bucket
+    target_bucket = "cbs-satellite-account-bucket005133826942"
+    target_prefix = "005133826942/s3_access_logs/covid-shield-exposure-config-staging/" 
   }
+
 }
 
 resource "aws_s3_bucket_policy" "exposure_config" {
@@ -57,7 +59,11 @@ resource "aws_s3_bucket" "firehose_waf_logs" {
       days = 90
     }
   }
-  #tfsec:ignore:AWS002 - Ignore log of logs
+
+  logging {
+    target_bucket = "cbs-satellite-account-bucket005133826942"
+    target_prefix = "005133826942/s3_access_logs/covid-shield-staging-waf-logs/"
+  }
 }
 
 ###
@@ -80,28 +86,11 @@ resource "aws_s3_bucket" "cloudfront_logs" {
       days = 90
     }
   }
-  #tfsec:ignore:AWS002 - Ignore log of logs
-}
-
-resource "aws_s3_bucket" "exposure_config_logs" {
-  bucket = "covid-shield-exposure-config-${var.environment}-logs"
-  acl    = "log-delivery-write"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
+  
+  logging {
+    target_bucket = "cbs-satellite-account-bucket005133826942"
+    target_prefix = "005133826942/s3_access_logs/covid-shield-staging-cloudfront-logs/"
   }
-
-  lifecycle_rule {
-    enabled = true
-
-    expiration {
-      days = 90
-    }
-  }
-  #tfsec:ignore:AWS002 - Ignore log of logs
 }
 
 resource "aws_s3_bucket_public_access_block" "firehose_waf_logs" {
@@ -115,15 +104,6 @@ resource "aws_s3_bucket_public_access_block" "firehose_waf_logs" {
 
 resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
   bucket = aws_s3_bucket.cloudfront_logs.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-resource "aws_s3_bucket_public_access_block" "exposure_config_logs" {
-  bucket = aws_s3_bucket.exposure_config_logs.id
 
   block_public_acls       = true
   block_public_policy     = true


### PR DESCRIPTION
Remove the autoscale configurations for ECS since those haven't worked
since we implemented green/blue deploys it's also not needed due to
current server utlization.

Add CBS logging so we stop polluting PR's with uneeded infra changes

Closes #64 
Closes https://github.com/cds-snc/covid-alert-server/issues/352