### PR TITLE
chore: renable rate limiting

### DIFF
--- a/server/aws/waf.tf
+++ b/server/aws/waf.tf
@@ -131,6 +131,202 @@ resource "aws_wafv2_web_acl" "key_submission" {
   }
 
   rule {
+    name     = "KeySubmissionClaimKeyURIRateLimit01"
+    priority = 101
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/claim-key"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit01"
+      sampled_requests_enabled   = true
+    }
+  }
+
+
+  rule {
+    name     = "KeySubmissionClaimKeyURIRateLimit02"
+    priority = 102
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/claim-key"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit02"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "KeySubmissionClaimKeyURIRateLimit03"
+    priority = 103
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/claim-key"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit03"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "KeySubmissionClaimKeyURIRateLimit04"
+    priority = 104
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/claim-key"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit04"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "KeySubmissionClaimKeyURIRateLimit05"
+    priority = 105
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 100
+        aggregate_key_type = "IP"
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/claim-key"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeySubmissionClaimKeyURIRateLimit05"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
     name     = "KeySubmissionURIs"
     priority = 200
 


### PR DESCRIPTION
Turn back on rate limiting since we are done stuffing the database

Associated with cds-snc/covid-alert-server#390

Undoing #66 