### PR TITLE
feat: make ECR image tags immutable

### DIFF
--- a/server/aws/ecr.tf
+++ b/server/aws/ecr.tf
@@ -5,7 +5,7 @@ locals {
 resource "aws_ecr_repository" "repository" {
   for_each             = toset(local.image_names)
   name                 = "covid-server/${each.value}"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true


### PR DESCRIPTION
Snyk flagged mutable tags as a potential security issue and as we currently have no requirement for mutable tags, I'm making this change. 