### PR TITLE
feat(submission) infrastructure deployment for metrics collection service

### DIFF
--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -1,0 +1,166 @@
+##
+#  Mectrics Collection API Gateway
+##
+
+resource "aws_api_gateway_rest_api" "metrics" {
+  name        = var.service_name
+  description = var.api-description
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+  tags = {
+    Name                  = var.service_name
+    Environment           = var.environment
+    (var.billing_tag_key) = var.billing_tag_value
+    Resource              = "API-Gateway"
+    Project               = var.project
+    Deployment            = "Terraform"
+  }
+}
+
+output "base_url" {
+  value = aws_api_gateway_deployment.metrics.invoke_url
+}
+
+resource "aws_api_gateway_resource" "create_resource" {
+  rest_api_id = aws_api_gateway_rest_api.metrics.id
+  parent_id   = aws_api_gateway_rest_api.metrics.root_resource_id
+  path_part   = var.service_name
+}
+
+resource "aws_api_gateway_method" "create_method" {
+  rest_api_id      = aws_api_gateway_rest_api.metrics.id
+  resource_id      = aws_api_gateway_resource.create_resource.id
+  http_method      = "POST"
+  authorization    = "NONE"
+  api_key_required = true
+}
+
+resource "aws_api_gateway_method_response" "response_200" {
+  rest_api_id = aws_api_gateway_rest_api.metrics.id
+  resource_id = aws_api_gateway_resource.create_resource.id
+  http_method = aws_api_gateway_method.create_method.http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_integration" "metrics" {
+  rest_api_id             = aws_api_gateway_rest_api.metrics.id
+  resource_id             = aws_api_gateway_method.create_method.resource_id
+  http_method             = aws_api_gateway_method.create_method.http_method
+  integration_http_method = "POST"
+  type                    = "AWS"
+  uri                     = aws_lambda_function.metrics.invoke_arn
+}
+
+resource "aws_api_gateway_integration_response" "metrics_response" {
+  depends_on = [
+    aws_api_gateway_integration.metrics
+  ]
+  http_method = aws_api_gateway_method.create_method.http_method
+  resource_id = aws_api_gateway_resource.create_resource.id
+  rest_api_id = aws_api_gateway_rest_api.metrics.id
+  status_code = aws_api_gateway_method_response.response_200.status_code
+}
+
+resource "aws_api_gateway_deployment" "metrics" {
+  depends_on  = [aws_api_gateway_integration.metrics]
+  rest_api_id = aws_api_gateway_rest_api.metrics.id
+}
+
+resource "aws_cloudwatch_log_group" "api_log_group" {
+  name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.metrics.id}/${var.environment}"
+  retention_in_days = 7
+  # ... potentially other configuration ...
+}
+
+resource "aws_api_gateway_stage" "metrics" {
+  depends_on           = [aws_cloudwatch_log_group.api_log_group]
+  deployment_id        = aws_api_gateway_deployment.metrics.id
+  rest_api_id          = aws_api_gateway_rest_api.metrics.id
+  stage_name           = var.environment
+  xray_tracing_enabled = true
+}
+
+resource "aws_api_gateway_usage_plan" "metrics_usage_plan" {
+  name = "${var.apiKeyName}_usage_plan"
+  depends_on = [
+    aws_api_gateway_stage.metrics
+  ]
+  api_stages {
+    api_id = aws_api_gateway_rest_api.metrics.id
+    stage  = var.environment
+  }
+}
+
+resource "aws_api_gateway_api_key" "metrics_api_key" {
+  name = var.apiKeyName
+}
+
+resource "aws_api_gateway_usage_plan_key" "main" {
+  key_id        = aws_api_gateway_api_key.metrics_api_key.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.metrics_usage_plan.id
+}
+
+resource "aws_api_gateway_account" "demo" {
+  cloudwatch_role_arn = aws_iam_role.api_gatway_cloudwatch_role.arn
+}
+
+resource "aws_iam_role" "api_gatway_cloudwatch_role" {
+  name = "${var.service_name}api_gateway_cloudwatch_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "apigateway.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "cloudwatch" {
+  name = "default"
+  role = aws_iam_role.api_gatway_cloudwatch_role.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:PutLogEvents",
+                "logs:GetLogEvents",
+                "logs:FilterLogEvents"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_api_gateway_method_settings" "method_settings" {
+  rest_api_id = aws_api_gateway_rest_api.metrics.id
+  stage_name  = aws_api_gateway_stage.metrics.stage_name
+  method_path = "${aws_api_gateway_resource.create_resource.path_part}/${aws_api_gateway_method.create_method.http_method}"
+
+  settings {
+    metrics_enabled        = true
+    logging_level          = "INFO"
+    throttling_burst_limit = var.api_gateway_burst
+    throttling_rate_limit  = var.api_gateway_rate
+  }
+}

--- a/server/aws/mc-lambda.tf
+++ b/server/aws/mc-lambda.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "metrics" {
 
   vpc_config {
     security_group_ids = [aws_security_group.lambda_sg.id]
-    subnet_ids         = aws_subnet.covidshield_private
+    subnet_ids         = aws_subnet.covidshield_private.*.id
   }
 
   tags = {

--- a/server/aws/mc-lambda.tf
+++ b/server/aws/mc-lambda.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "metrics" {
 
   vpc_config {
     security_group_ids = [aws_security_group.lambda_sg.id]
-    subnet_ids         = [aws_subnet.covidshield_private.id]
+    subnet_ids         = aws_subnet.covidshield_private
   }
 
   tags = {

--- a/server/aws/mc-lambda.tf
+++ b/server/aws/mc-lambda.tf
@@ -1,0 +1,113 @@
+##
+#  Mectrics Collection Lambda
+##
+
+resource "aws_lambda_function" "metrics" {
+  function_name = var.service_name
+  description   = var.lambda-description
+  #  filename      = "/tmp/lambda_validate_deploy.rb.zip"
+  s3_bucket = var.lambda_code
+  s3_key    = var.lambda-function-code
+
+  handler = var.lambda-function-handler
+  runtime = var.lambda-function-runtime
+  role    = aws_iam_role.role.arn
+  environment {
+    variables = {
+      dataBucket = "${var.s3_raw_metrics_bucket_name}-${data.aws_caller_identity.current.account_id}"
+      fileLoca   = "metrics"
+    }
+  }
+
+  vpc_config {
+    security_group_ids = [aws_security_group.lambda_sg.id]
+    subnet_ids         = [aws_subnet.covidshield_private.id]
+  }
+
+  tags = {
+    Name                  = var.service_name
+    Resource              = "Lambda"
+    Environment           = var.environment
+    (var.billing_tag_key) = var.billing_tag_value
+    Project               = var.project
+    Deployment            = "Terraform"
+  }
+}
+
+resource "aws_security_group" "lambda_sg" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = aws_vpc.covidshield.id
+
+
+}
+
+resource "aws_iam_role" "role" {
+  name = "${var.service_name}.role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cloudwatch_log_group" "metrics" {
+  name              = "/aws/lambda/${var.service_name}"
+  retention_in_days = 14
+}
+
+resource "aws_iam_policy" "lambda_logging" {
+  name = var.service_name
+  path = "/"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*",
+      "Effect": "Allow"
+    },
+    {
+      "Sid": "VisualEditor0",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${var.s3_raw_metrics_bucket_name}-${data.aws_caller_identity.current.account_id}/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.lambda_logging.arn
+}
+
+resource "aws_lambda_permission" "apigw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.metrics.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.metrics.execution_arn}/*/POST/${var.service_name}"
+}
+

--- a/server/aws/mc-s3-buckets.tf
+++ b/server/aws/mc-s3-buckets.tf
@@ -1,0 +1,78 @@
+##
+#  Mectrics Collection S3 Bucket and Logging
+##
+
+resource "aws_s3_bucket" "raw_metrics_bucket" {
+  bucket = "${var.s3_raw_metrics_bucket_name}-${data.aws_caller_identity.current.account_id}"
+  acl    = "private"
+
+  depends_on = [aws_s3_bucket.raw_metrics_bucket_logs]
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = {
+    Name                  = var.s3_raw_metrics_bucket_name
+    Environment           = var.environment
+    Resource              = "S3",
+    Project               = var.project,
+    (var.billing_tag_key) = var.billing_tag_value
+    Deployment            = "Terraform"
+  }
+
+  logging {
+    target_bucket = "${var.s3_raw_metrics_bucket_logging_name}-${data.aws_caller_identity.current.account_id}"
+    target_prefix = "${var.service_name}/logs${data.aws_caller_identity.current.account_id}"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "raw_metrics_bucket" {
+  bucket                  = aws_s3_bucket.raw_metrics_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket" "raw_metrics_bucket_logs" {
+  bucket = "${var.s3_raw_metrics_bucket_logging_name}-${data.aws_caller_identity.current.account_id}"
+  acl    = "log-delivery-write"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+
+  tags = {
+    Name                  = var.s3_raw_metrics_bucket_logging_name
+    Environment           = var.environment
+    Resource              = "S3",
+    Project               = var.project,
+    (var.billing_tag_key) = var.billing_tag_value
+    Deployment            = "Terraform"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "raw_metrics_bucket_logs" {
+  bucket                  = aws_s3_bucket.raw_metrics_bucket_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/server/aws/mc-variables.tf
+++ b/server/aws/mc-variables.tf
@@ -1,0 +1,95 @@
+##
+#  Mectrics Collection Variables File mc-
+##
+
+variable "service_name" {
+  type        = string
+  description = "Name of the service"
+  default     = "cds-covid-alert-create-metric-record"
+}
+
+variable "owner" {
+  type        = string
+  description = "Name of the owner"
+  default     = "terraform-lambda-zips"
+}
+
+variable "project" {
+  type        = string
+  description = "Name of the project"
+  default     = "COVID-Alert"
+}
+
+variable "lambda_code" {
+  type        = string
+  description = "Name of the project"
+  default     = "terraform-lambda-zips"
+}
+
+variable "s3_raw_metrics_bucket_name" {
+  type        = string
+  description = "S3 bucket that holds the raw mentric counts"
+  default     = "cds-covid-alert-bucket-dev"
+}
+
+variable "s3_raw_metrics_bucket_logging_name" {
+  type        = string
+  description = "S3 bucket that holds the logs for the metrics bucket"
+  default     = "cds-covid-alert-bucket-logging-dev"
+}
+
+variable "api-description" {
+  type    = string
+  default = "Terraform Serverless api for COVID Alert metrics collection"
+}
+
+variable "mks-description" {
+  type    = string
+  default = "This CMK is used to encrypt the metrics bucket"
+}
+
+variable "lambda-description" {
+  type    = string
+  default = "Lambda function for collecting metrics records"
+}
+
+variable "lambda-function-code" {
+  type    = string
+  default = "createRecord.zip"
+}
+
+variable "lambda-function-runtime" {
+  type    = string
+  default = "nodejs12.x"
+}
+
+variable "lambda-function-handler" {
+  type    = string
+  default = "index.handler"
+}
+
+variable "waf-description" {
+  type    = string
+  default = "WAF for API protection"
+}
+
+variable "apiKeyName" {
+  type        = string
+  description = "API Key Name"
+  default     = "Dev-Key"
+}
+
+variable "apiKeyDescription" {
+  type    = string
+  default = "API Key for Development"
+}
+
+variable "api_gateway_rate" {
+  type    = string
+  default = 10000
+}
+
+variable "api_gateway_burst" {
+  type    = string
+  default = 5000
+}

--- a/server/aws/mc-variables.tf
+++ b/server/aws/mc-variables.tf
@@ -23,7 +23,7 @@ variable "project" {
 variable "lambda_code" {
   type        = string
   description = "Name of the project"
-  default     = "terraform-lambda-zips"
+  default     = "cds-terraform-lambda-zips"
 }
 
 variable "s3_raw_metrics_bucket_name" {

--- a/server/aws/mc-waf.tf
+++ b/server/aws/mc-waf.tf
@@ -1,0 +1,166 @@
+##
+#  Mectrics Collection Dev WAF
+##
+
+resource "aws_wafv2_web_acl" "metrics_collection" {
+  name        = "metrics_collection1"
+  description = var.waf-description
+  scope       = "REGIONAL"
+
+  default_action {
+    block {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesAmazonIpReputationList"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesAmazonIpReputationList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 3
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesKnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesLinuxRuleSet"
+    priority = 4
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesLinuxRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesLinuxRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 5
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesSQLiRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "KeyRetrievalRateLimit"
+    priority = 101
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 10000
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KeyRetrievalRateLimit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  tags = {
+    Name                  = var.service_name
+    Environment           = var.environment
+    Resource              = "WAF",
+    Project               = var.project,
+    (var.billing_tag_key) = var.billing_tag_value
+    Deployment            = "Terraform"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "metrics-submission"
+    sampled_requests_enabled   = false
+  }
+}
+
+
+resource "aws_wafv2_web_acl_association" "waf_association" {
+  resource_arn = aws_api_gateway_stage.metrics.arn
+  web_acl_arn  = aws_wafv2_web_acl.metrics_collection.arn
+}


### PR DESCRIPTION
### Summary
This Terraform deploys the architecture shown in the image below. It is a WAF secured API Gateway with one POST method for calling a Lambda function that will take a JSON payload of metrics information and place it in an encrypted S3 bucket. The encryption used is AWS Key Management Service (KMS) Customer Managed Key (CMK). issue #74 

-The POST method requires an APIKey that is auto-generated and infrastructure deployment. 
-The Lambda function code is pulled from an S3 bucket deployed via CICD from the Covid Server repository.
-The Lambda function requires 3 environment variables, dataKey : auto-generated from Terraform, dataBucket : the bucket that will receive the  metrics objects: target in mc-variables.tf file and fileLoca : the prefix of the dataBucket where the Raw metrics will arrive. 
-The Lambda only has Encrypt and putObject policy permissions
-The WAF configuration uses AWS recommended guards

![image](https://user-images.githubusercontent.com/6564400/106369249-c8dc1500-631d-11eb-9197-ee4739bfdeb7.png)

### Still to be done
- Testing with COVID Alert deployment 
- Deploying the Lambda inside the COVID SHIELD VPC and private subnets

### Testing to come