### PR TITLE
feat: adds a domain name to the metrics collection lambda

### DIFF
--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -19,6 +19,11 @@ resource "aws_api_gateway_rest_api" "metrics" {
   }
 }
 
+resource "aws_api_gateway_domain_name" "metrics" {
+  certificate_arn = aws_acm_certificate.covidshield.arn
+  domain_name     = "metrics.${aws_route53_zone.covidshield.name}"
+}
+
 output "base_url" {
   value = aws_api_gateway_deployment.metrics.invoke_url
 }

--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -20,8 +20,9 @@ resource "aws_api_gateway_rest_api" "metrics" {
 }
 
 resource "aws_api_gateway_domain_name" "metrics" {
-  certificate_arn = aws_acm_certificate.covidshield.arn
-  domain_name     = "metrics.${aws_route53_zone.covidshield.name}"
+  regional_certificate_arn = aws_acm_certificate.covidshield.arn
+  domain_name              = "metrics.${aws_route53_zone.covidshield.name}"
+  security_policy          = "TLS_1_2"
 }
 
 output "base_url" {

--- a/server/aws/route53.tf
+++ b/server/aws/route53.tf
@@ -95,3 +95,19 @@ resource "aws_route53_health_check" "covidshield_key_submission_healthcheck" {
     (var.billing_tag_key) = var.billing_tag_value
   }
 }
+
+###
+# Route53 Record - Metrics Submission
+###
+
+resource "aws_route53_record" "covidshield_metrics_submission" {
+  zone_id = aws_route53_zone.covidshield.zone_id
+  name    = "metrics.${aws_route53_zone.covidshield.name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_api_gateway_domain_name.metrics.cloudfront_domain_name
+    zone_id                = aws_api_gateway_domain_name.metrics.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/server/aws/route53.tf
+++ b/server/aws/route53.tf
@@ -106,8 +106,8 @@ resource "aws_route53_record" "covidshield_metrics_submission" {
   type    = "A"
 
   alias {
-    name                   = aws_api_gateway_domain_name.metrics.cloudfront_domain_name
-    zone_id                = aws_api_gateway_domain_name.metrics.cloudfront_zone_id
+    name                   = aws_api_gateway_domain_name.metrics.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.metrics.regional_zone_id
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
This PR adds a domain name: `metrics.${aws_route53_zone.covidshield.name}` to the system which hooks up to a lambda available through the API gateway and uses the existing wildcard SSL certificate for HTTPS.