### PR TITLE
fix: explicitly add REGIONAL designation and add base path mapping

### DIFF
--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -29,6 +29,13 @@ resource "aws_api_gateway_domain_name" "metrics" {
   }
 }
 
+resource "aws_api_gateway_base_path_mapping" "metrics" {
+  api_id      = aws_api_gateway_rest_api.metrics.id
+  stage_name  = aws_api_gateway_stage.metrics.stage_name
+  domain_name = aws_api_gateway_domain_name.metrics.domain_name
+}
+
+
 output "base_url" {
   value = aws_api_gateway_deployment.metrics.invoke_url
 }

--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -23,6 +23,10 @@ resource "aws_api_gateway_domain_name" "metrics" {
   regional_certificate_arn = aws_acm_certificate.covidshield.arn
   domain_name              = "metrics.${aws_route53_zone.covidshield.name}"
   security_policy          = "TLS_1_2"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
 }
 
 output "base_url" {


### PR DESCRIPTION
Adds an explicit REGIONAL designation to the API gateway domain. Also adds a `aws_api_gateway_base_path_mapping` resource to link the base domain to the path.