### PR TITLE
fix: adds proper egress to lambda SG

### DIFF
--- a/server/aws/mc-lambda.tf
+++ b/server/aws/mc-lambda.tf
@@ -35,13 +35,14 @@ resource "aws_lambda_function" "metrics" {
 }
 
 resource "aws_security_group" "lambda_sg" {
-  name        = "allow_tls"
-  description = "Allow TLS inbound traffic"
+  name        = "allow_lambda_to_s3"
+  description = "Allow TLS outbound traffic to S3"
   vpc_id      = aws_vpc.covidshield.id
   egress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    prefix_list_ids = [aws_vpc_endpoint.s3.prefix_list_id]
   }
 }
 


### PR DESCRIPTION
This PR adds a `prefix_list` to the security group handling the outbound traffic from the metrics lambda to S3. The S3 private link to our VPC is a gateway and not attached through an ENI like many other private links. As a result it does not get an IP address inside our VPC.