### PR TITLE
feat: model for JSON Schema Validation

### DIFF
--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -27,6 +27,21 @@ resource "aws_api_gateway_base_path_mapping" "metrics" {
   domain_name = aws_api_gateway_domain_name.metrics.domain_name
 }
 
+resource "aws_api_gateway_model" "metrics_model" {
+    rest_api_id  = aws_api_gateway_rest_api.metrics.id
+    name         = "${aws_api_gateway_rest_api.metrics.name}-model"
+    description  = "Metrics json schema"
+    content_type = "application/json"
+
+  schema = file("models/metrics.json")
+}
+
+resource "aws_api_gateway_request_validator" "metrics_model" {
+  name         = "${aws_api_gateway_rest_api.metrics.name}-validator"
+  rest_api_id                 = aws_api_gateway_rest_api.metrics.id
+  validate_request_body       = true
+  validate_request_parameters = false
+}
 
 output "base_url" {
   value = aws_api_gateway_deployment.metrics.invoke_url

--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -28,16 +28,16 @@ resource "aws_api_gateway_base_path_mapping" "metrics" {
 }
 
 resource "aws_api_gateway_model" "metrics_model" {
-    rest_api_id  = aws_api_gateway_rest_api.metrics.id
-    name         = "${aws_api_gateway_rest_api.metrics.name}-model"
-    description  = "Metrics json schema"
-    content_type = "application/json"
+  rest_api_id  = aws_api_gateway_rest_api.metrics.id
+  name         = "${aws_api_gateway_rest_api.metrics.name}-model"
+  description  = "Metrics json schema"
+  content_type = "application/json"
 
   schema = file("models/metrics.json")
 }
 
 resource "aws_api_gateway_request_validator" "metrics_model" {
-  name         = "${aws_api_gateway_rest_api.metrics.name}-validator"
+  name                        = "${aws_api_gateway_rest_api.metrics.name}-validator"
   rest_api_id                 = aws_api_gateway_rest_api.metrics.id
   validate_request_body       = true
   validate_request_parameters = false

--- a/server/aws/models/metrics.json
+++ b/server/aws/models/metrics.json
@@ -1,0 +1,450 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "title": "The root schema",
+  "description": "The root schema comprises the entire JSON document.",
+  "default": {},
+  "examples": [
+      {
+          "metricstimestamp": 1611324826295,
+          "appversion": "999",
+          "appos": "ios",
+          "payload": [
+              {
+                  "identifier": "installed",
+                  "region": "None",
+                  "timestamp": 1611323998012
+              },
+              {
+                  "identifier": "onboarded",
+                  "region": "QC",
+                  "timestamp": 1611324024314,
+                  "pushnotification": "true",
+                  "frameworkenabled": "true"
+              },
+              {
+                  "identifier": "exposed",
+                  "region": "QC",
+                  "timestamp": 1611324820294
+              },
+              {
+                  "identifier": "otk-no-date",
+                  "region": "QC",
+                  "timestamp": 1611324825778
+              },
+              {
+                  "identifier": "otk-with-date",
+                  "region": "QC",
+                  "timestamp": 1611324825778
+              },
+              {
+                  "identifier": "en-toggle",
+                  "region": "QC",
+                  "timestamp": 1611324825778,
+                  "state": "true"
+              },
+              {
+                  "identifier": "exposed-clear",
+                  "region": "QC",
+                  "timestamp": 1611324825778,
+                  "hoursSinceExposureDetectedAt": "2"
+              },
+              {
+                  "identifier": "background-check",
+                  "region": "QC",
+                  "timestamp": 1611324825778,
+                  "count": "4"
+              }
+          ]
+      }
+  ],
+  "required": [
+      "metricstimestamp",
+      "appversion",
+      "appos",
+      "payload"
+  ],
+  "properties": {
+      "metricstimestamp": {
+          "$id": "#/properties/metricstimestamp",
+          "type": "integer",
+          "title": "The metricstimestamp schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": 0,
+          "examples": [
+              1611324826295
+          ]
+      },
+      "appversion": {
+          "$id": "#/properties/appversion",
+          "type": "string",
+          "title": "The appversion schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": "",
+          "examples": [
+              "999"
+          ]
+      },
+      "appos": {
+          "$id": "#/properties/appos",
+          "type": "string",
+          "title": "The appos schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": "",
+          "examples": [
+              "ios"
+          ]
+      },
+      "payload": {
+          "$id": "#/properties/payload",
+          "type": "array",
+          "title": "The payload schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": [],
+          "examples": [
+              [
+                  {
+                      "identifier": "installed",
+                      "region": "None",
+                      "timestamp": 1611323998012
+                  },
+                  {
+                      "identifier": "onboarded",
+                      "region": "QC",
+                      "timestamp": 1611324024314,
+                      "pushnotification": "true",
+                      "frameworkenabled": "true"
+                  }
+              ]
+          ],
+          "additionalItems": true,
+          "items": {
+              "$id": "#/properties/payload/items",
+              "anyOf": [
+                  {
+                      "$id": "#/properties/payload/items/anyOf/0",
+                      "type": "object",
+                      "title": "The first anyOf schema",
+                      "description": "An explanation about the purpose of this instance.",
+                      "default": {},
+                      "examples": [
+                          {
+                              "identifier": "installed",
+                              "region": "None",
+                              "timestamp": 1611323998012
+                          }
+                      ],
+                      "required": [
+                          "identifier",
+                          "region",
+                          "timestamp"
+                      ],
+                      "properties": {
+                          "identifier": {
+                              "$id": "#/properties/payload/items/anyOf/0/properties/identifier",
+                              "type": "string",
+                              "title": "The identifier schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "installed"
+                              ]
+                          },
+                          "region": {
+                              "$id": "#/properties/payload/items/anyOf/0/properties/region",
+                              "type": "string",
+                              "title": "The region schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "None"
+                              ]
+                          },
+                          "timestamp": {
+                              "$id": "#/properties/payload/items/anyOf/0/properties/timestamp",
+                              "type": "integer",
+                              "title": "The timestamp schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": 0,
+                              "examples": [
+                                  1611323998012
+                              ]
+                          }
+                      },
+                      "additionalProperties": true
+                  },
+                  {
+                      "$id": "#/properties/payload/items/anyOf/1",
+                      "type": "object",
+                      "title": "The second anyOf schema",
+                      "description": "An explanation about the purpose of this instance.",
+                      "default": {},
+                      "examples": [
+                          {
+                              "identifier": "onboarded",
+                              "region": "QC",
+                              "timestamp": 1611324024314,
+                              "pushnotification": "true",
+                              "frameworkenabled": "true"
+                          }
+                      ],
+                      "required": [
+                          "identifier",
+                          "region",
+                          "timestamp",
+                          "pushnotification",
+                          "frameworkenabled"
+                      ],
+                      "properties": {
+                          "identifier": {
+                              "$id": "#/properties/payload/items/anyOf/1/properties/identifier",
+                              "type": "string",
+                              "title": "The identifier schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "onboarded"
+                              ]
+                          },
+                          "region": {
+                              "$id": "#/properties/payload/items/anyOf/1/properties/region",
+                              "type": "string",
+                              "title": "The region schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "QC"
+                              ]
+                          },
+                          "timestamp": {
+                              "$id": "#/properties/payload/items/anyOf/1/properties/timestamp",
+                              "type": "integer",
+                              "title": "The timestamp schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": 0,
+                              "examples": [
+                                  1611324024314
+                              ]
+                          },
+                          "pushnotification": {
+                              "$id": "#/properties/payload/items/anyOf/1/properties/pushnotification",
+                              "type": "string",
+                              "title": "The pushnotification schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "true"
+                              ]
+                          },
+                          "frameworkenabled": {
+                              "$id": "#/properties/payload/items/anyOf/1/properties/frameworkenabled",
+                              "type": "string",
+                              "title": "The frameworkenabled schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "true"
+                              ]
+                          }
+                      },
+                      "additionalProperties": true
+                  },
+                  {
+                      "$id": "#/properties/payload/items/anyOf/2",
+                      "type": "object",
+                      "title": "The third anyOf schema",
+                      "description": "An explanation about the purpose of this instance.",
+                      "default": {},
+                      "examples": [
+                          {
+                              "identifier": "en-toggle",
+                              "region": "QC",
+                              "timestamp": 1611324825778,
+                              "state": "true"
+                          }
+                      ],
+                      "required": [
+                          "identifier",
+                          "region",
+                          "timestamp",
+                          "state"
+                      ],
+                      "properties": {
+                          "identifier": {
+                              "$id": "#/properties/payload/items/anyOf/2/properties/identifier",
+                              "type": "string",
+                              "title": "The identifier schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "en-toggle"
+                              ]
+                          },
+                          "region": {
+                              "$id": "#/properties/payload/items/anyOf/2/properties/region",
+                              "type": "string",
+                              "title": "The region schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "QC"
+                              ]
+                          },
+                          "timestamp": {
+                              "$id": "#/properties/payload/items/anyOf/2/properties/timestamp",
+                              "type": "integer",
+                              "title": "The timestamp schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": 0,
+                              "examples": [
+                                  1611324825778
+                              ]
+                          },
+                          "state": {
+                              "$id": "#/properties/payload/items/anyOf/2/properties/state",
+                              "type": "string",
+                              "title": "The state schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "true"
+                              ]
+                          }
+                      },
+                      "additionalProperties": true
+                  },
+                  {
+                      "$id": "#/properties/payload/items/anyOf/3",
+                      "type": "object",
+                      "title": "The fourth anyOf schema",
+                      "description": "An explanation about the purpose of this instance.",
+                      "default": {},
+                      "examples": [
+                          {
+                              "identifier": "exposed-clear",
+                              "region": "QC",
+                              "timestamp": 1611324825778,
+                              "hoursSinceExposureDetectedAt": "2"
+                          }
+                      ],
+                      "required": [
+                          "identifier",
+                          "region",
+                          "timestamp",
+                          "hoursSinceExposureDetectedAt"
+                      ],
+                      "properties": {
+                          "identifier": {
+                              "$id": "#/properties/payload/items/anyOf/3/properties/identifier",
+                              "type": "string",
+                              "title": "The identifier schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "exposed-clear"
+                              ]
+                          },
+                          "region": {
+                              "$id": "#/properties/payload/items/anyOf/3/properties/region",
+                              "type": "string",
+                              "title": "The region schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "QC"
+                              ]
+                          },
+                          "timestamp": {
+                              "$id": "#/properties/payload/items/anyOf/3/properties/timestamp",
+                              "type": "integer",
+                              "title": "The timestamp schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": 0,
+                              "examples": [
+                                  1611324825778
+                              ]
+                          },
+                          "hoursSinceExposureDetectedAt": {
+                              "$id": "#/properties/payload/items/anyOf/3/properties/hoursSinceExposureDetectedAt",
+                              "type": "string",
+                              "title": "The hoursSinceExposureDetectedAt schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "2"
+                              ]
+                          }
+                      },
+                      "additionalProperties": true
+                  },
+                  {
+                      "$id": "#/properties/payload/items/anyOf/4",
+                      "type": "object",
+                      "title": "The fifth anyOf schema",
+                      "description": "An explanation about the purpose of this instance.",
+                      "default": {},
+                      "examples": [
+                          {
+                              "identifier": "background-check",
+                              "region": "QC",
+                              "timestamp": 1611324825778,
+                              "count": "4"
+                          }
+                      ],
+                      "required": [
+                          "identifier",
+                          "region",
+                          "timestamp",
+                          "count"
+                      ],
+                      "properties": {
+                          "identifier": {
+                              "$id": "#/properties/payload/items/anyOf/4/properties/identifier",
+                              "type": "string",
+                              "title": "The identifier schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "background-check"
+                              ]
+                          },
+                          "region": {
+                              "$id": "#/properties/payload/items/anyOf/4/properties/region",
+                              "type": "string",
+                              "title": "The region schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "QC"
+                              ]
+                          },
+                          "timestamp": {
+                              "$id": "#/properties/payload/items/anyOf/4/properties/timestamp",
+                              "type": "integer",
+                              "title": "The timestamp schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": 0,
+                              "examples": [
+                                  1611324825778
+                              ]
+                          },
+                          "count": {
+                              "$id": "#/properties/payload/items/anyOf/4/properties/count",
+                              "type": "string",
+                              "title": "The count schema",
+                              "description": "An explanation about the purpose of this instance.",
+                              "default": "",
+                              "examples": [
+                                  "4"
+                              ]
+                          }
+                      },
+                      "additionalProperties": true
+                  }
+              ]
+          }
+      }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
Adds a JSON Schema model and validates call to Lambda with it. 

Schema was created by taking the following JSON doc: 

```
{
    "metricstimestamp": 1611324826295,
    "appversion": "999",
    "appos": "ios",
    "payload": [{
            "identifier": "installed",
            "region": "None",
            "timestamp": 1611323998012
        },
        {
            "identifier": "onboarded",
            "region": "QC",
            "timestamp": 1611324024314,
            "pushnotification": "true",
            "frameworkenabled": "true"
        },
        {
            "identifier": "exposed",
            "region": "QC",
            "timestamp": 1611324820294
        },
        {
            "identifier": "otk-no-date",
            "region": "QC",
            "timestamp": 1611324825778
        },
        {
            "identifier": "otk-with-date",
            "region": "QC",
            "timestamp": 1611324825778
        },
        {
            "identifier": "en-toggle",
            "region": "QC",
            "timestamp": 1611324825778,
            "state": "true"
        },
        {
            "identifier": "exposed-clear",
            "region": "QC",
            "timestamp": 1611324825778,
            "hoursSinceExposureDetectedAt": "2"
        },
        {
            "identifier": "background-check",
            "region": "QC",
            "timestamp": 1611324825778,
            "count": "4"
        }
    ]
}
```


And running it through: https://jsonschema.net