### PR TITLE
feat: rename service to not reference org

### DIFF
--- a/server/aws/mc-variables.tf
+++ b/server/aws/mc-variables.tf
@@ -5,7 +5,7 @@
 variable "service_name" {
   type        = string
   description = "Name of the service"
-  default     = "cds-covid-alert-create-metric-record"
+  default     = "save-metrics"
 }
 
 variable "owner" {


### PR DESCRIPTION
rename the service, FYI this will recreate entire metrics service