### PR TITLE
feat: stashes create metrics script inside TF

### DIFF
--- a/server/aws/lambda/create_metric.js
+++ b/server/aws/lambda/create_metric.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const
+    AWS = require('aws-sdk'),
+    S3 = new AWS.S3(),
+    crypto = require('crypto');
+    
+function uuidv4() {
+  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+    (c ^ crypto.randomFillSync(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  );
+}
+
+exports.handler = async (event, context) => {
+
+    const bucket = process.env.dataBucket;
+    const filePath = process.env.fileLoca;
+    const filename = uuidv4();
+    let transactionStatus = "FAILED";
+    var body = JSON.stringify(event);
+
+    const bucketParams = {
+        Bucket: bucket + "/" + filePath,
+        Key: filename + '.json',
+        Body: body,
+        ServerSideEncryption: 'AES256'
+    };
+
+    /* The puObject call forces a promise because the result returned may not be a promise.  */
+    try {
+        const resp = await S3.putObject(bucketParams).promise();
+        transactionStatus = { "status": "RECORD_CREATED", "key": filename};
+    } catch (err) {
+        transactionStatus = { "status": "UPLOAD FAILED"};
+    }
+
+    return transactionStatus;
+};

--- a/server/aws/mc-lambda.tf
+++ b/server/aws/mc-lambda.tf
@@ -2,16 +2,24 @@
 #  Mectrics Collection Lambda
 ##
 
+data "archive_file" "lambda_create_metric" {
+  type        = "zip"
+  source_file = "lambda/create_metric.js"
+  output_path = "/tmp/create_metric.js.zip"
+}
+
+
 resource "aws_lambda_function" "metrics" {
   function_name = var.service_name
   description   = var.lambda-description
-  #  filename      = "/tmp/lambda_validate_deploy.zip"
-  s3_bucket = var.lambda_code
-  s3_key    = var.lambda-function-code
+  filename      = "/tmp/lambda_create_metric.zip"
+
+  source_code_hash = data.archive_file.lambda_create_metric.output_base64sha256
 
   handler = var.lambda-function-handler
   runtime = var.lambda-function-runtime
   role    = aws_iam_role.role.arn
+
   environment {
     variables = {
       dataBucket = "${var.s3_raw_metrics_bucket_name}-${data.aws_caller_identity.current.account_id}"

--- a/server/aws/mc-variables.tf
+++ b/server/aws/mc-variables.tf
@@ -60,7 +60,7 @@ variable "lambda-function-code" {
 
 variable "lambda-function-runtime" {
   type    = string
-  default = "nodejs14.x"
+  default = "nodejs12.x"
 }
 
 variable "lambda-function-handler" {

--- a/server/aws/mc-variables.tf
+++ b/server/aws/mc-variables.tf
@@ -60,7 +60,7 @@ variable "lambda-function-code" {
 
 variable "lambda-function-runtime" {
   type    = string
-  default = "nodejs12.x"
+  default = "nodejs14.x"
 }
 
 variable "lambda-function-handler" {


### PR DESCRIPTION
This PR changes the create metrics lambda into a simple script without any dependencies. The previous deploy method method included 8 MB of dependencies such as the AWS client and a UUID function which could easily be loaded from the environment in the case of the former, and replaced by a function in the case of the later. 