### PR TITLE
feat: convert to lambda proxy

### DIFF
--- a/server/aws/lambda/create_metric.js
+++ b/server/aws/lambda/create_metric.js
@@ -39,8 +39,9 @@ exports.handler = async (event, context) => {
         transactionStatus.statusCode = 200;
         transactionStatus.body = JSON.stringify({ "status": "RECORD CREATED", "key": filename});
     } catch (err) {
-        console.log(err)
-        throw new Error("UPLOAD FAILED")
+        console.log(err);
+        transactionStatus.statusCode = 500;
+        transactionStatus.body= JSON.stringify({"status" : "UPLOAD FAILED"});
     }
 
     return transactionStatus;


### PR DESCRIPTION
# Fixes:

Convert save-metrics lambda to an AWS Lambda Proxy

## Description of what your PR accomplishes:

Instead of using integration mapping to map results from the lambda to
specific error codes and return values it just leverages the "Empty" and
"Error" models for 200 and 500 errors respectively which pass through
the return json to the client

## Why this approach? Any notable design decisions?

AWS reccomends that all new lambda's be built using lambda proxys and so
that's what this does.


## Anything the reviewers should focus on? Any discussion points?

TF Plan output to make sure nothing untoward happens
