### PR TITLE
fix: only log body, and force a deploy of lambda

### DIFF
--- a/server/aws/lambda/create_metric.js
+++ b/server/aws/lambda/create_metric.js
@@ -29,7 +29,7 @@ exports.handler = async (event, context) => {
     const bucketParams = {
         Bucket: `${bucket}/${filePath}/${todaysDate()}`,
         Key: `${filename}.json`,
-        Body: JSON.stringify(event),
+        Body: JSON.stringify(event.body),
         ServerSideEncryption: 'AES256'
     };
 

--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -114,9 +114,10 @@ resource "aws_api_gateway_integration_response" "metrics_response" {
 resource "aws_api_gateway_deployment" "metrics" {
   rest_api_id = aws_api_gateway_rest_api.metrics.id
 
-  # force a deploy
-  variables {
-    deployed_at = timestamp()
+  # Forces a redeploy of the gateway
+  # TODO: use a hash of create_metric.js, mc-*.tf files to trigger redeployment
+  triggers {
+    redeployment = timestamp()
   }
 }
 

--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -113,6 +113,11 @@ resource "aws_api_gateway_integration_response" "metrics_response" {
 
 resource "aws_api_gateway_deployment" "metrics" {
   rest_api_id = aws_api_gateway_rest_api.metrics.id
+
+  # force a deploy
+  variables {
+    deployed_at = timestamp()
+  }
 }
 
 resource "aws_cloudwatch_log_group" "api_log_group" {

--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -116,7 +116,7 @@ resource "aws_api_gateway_deployment" "metrics" {
 
   # Forces a redeploy of the gateway
   # TODO: use a hash of create_metric.js, mc-*.tf files to trigger redeployment
-  triggers {
+  triggers = {
     redeployment = timestamp()
   }
 }


### PR DESCRIPTION
Instead of logging the entire payload we only log the body. 
Add a variable to the deployment resource so it always deploys on a plan. This will probably be removed when we decouple the lambda code. 
