### PR TITLE
feat: parse json before stringifying and storing

### DIFF
--- a/server/aws/lambda/create_metric.js
+++ b/server/aws/lambda/create_metric.js
@@ -26,10 +26,12 @@ exports.handler = async (event, context) => {
         isBase64Encoded:  false
     };
 
+    const body = JSON.parse(event.body)
+
     const bucketParams = {
         Bucket: `${bucket}/${filePath}/${todaysDate()}`,
         Key: `${filename}.json`,
-        Body: JSON.stringify(event.body),
+        Body: JSON.stringify(body),
         ServerSideEncryption: 'AES256'
     };
 


### PR DESCRIPTION
This will remove all the whitespace and pack it as tightly as possible,
to make it smaller we will need to compress or change to a different
data structure such as protobufs.

