### PR TITLE
feat: adds a .well-known dir to retreival for app redirect

### DIFF
--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -34,6 +34,14 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     }
   }
 
+  origin {
+    domain_name = aws_s3_bucket.well_known.bucket_regional_domain_name
+    origin_id   = "covid-shield-well-known-${var.environment}"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    }
+  }
 
   enabled         = true
   is_ipv6_enabled = true
@@ -67,6 +75,28 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "covid-shield-exposure-config-${var.environment}"
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "/.well-known/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "covid-shield-well-known-${var.environment}"
 
     forwarded_values {
       query_string = false


### PR DESCRIPTION
This PR creates another S3 bucket to serve static files from the `.well-known` path. This is to facilitate the work being done in https://github.com/cds-snc/covid-alert-exposure-configuration-staging/pull/71