### PR TITLE
fix: work on aggregate functionality

### DIFF
--- a/server/aws/lambda/aggregate_values.js
+++ b/server/aws/lambda/aggregate_values.js
@@ -1,17 +1,105 @@
 'use strict';
 
 const AWS = require("aws-sdk");
+const documentClient = new AWS.DynamoDB.DocumentClient();
+const crypto = require("crypto")
 
+function createHash(sk, appversion, appos, pl)
+    return crypto.createHash('md5')
+        .update(`${sk}_${pl.region}_${appversion}_${appos}_${pl.identifier}`)
+        .digest('hex');
+}
 
-exports.handler = (event, context, callback) => {
+function generatePayload(a) {
 
+    const updateCount = parseInt(a.count || 1,10);
+
+    return {
+        TableName: "aggregate_metrics",
+        Key: {
+            "pk" : a.pk,
+            "date" : a.date
+        },
+        UpdateExpression: `
+        SET #appversion = :appversion,
+            #appos = :appos,
+            #region = :region,
+            #identifier = :identifier,
+            #count = #count + :count`,
+        ExpressionAttributeNames: {
+            '#count' : 'count',
+            "#appversion": 'appversion',
+            "#appos": 'appos',
+            "#region": 'region',
+            "#identifier": 'identifier'
+        },
+        ExpressionAttributeValues: {
+            ":appversion": a.appversion,
+            ":appos": a.appos,
+            ":region": a.region,
+            ":identifier": a.identifier,
+            ":count": updateCount,
+        }
+    };
+}
+
+function pinDate(timestamp) {
+    let d = new Date();
+    d.setTime(timestamp);
+    d.setHours(0,0,0,0);
+    return d;
+}
+
+function aggregateEvents(event){
+    const aggregates = {}; 
     event.Records.forEach((record) => {
-        console.log('Stream record: ', JSON.stringify(record, null, 2));
-      if(record.eventName === 'INSERT') { 
-        console.log('uuid: ', record.dynamodb.NewImage.uuid.S);
-        console.log('ttl: ', record.dynamodb.NewImage.uuid.N);
-        console.log('raw: ', record.dynamodb.NewImage.uuid.S);
 
-      }
+        console.log('Stream record: ', JSON.stringify(record, null, 2));
+
+        if(record.eventName === 'INSERT') {
+
+            const raw = JSON.parse(record.dynamodb.NewImage.raw.S);
+            raw.payload.forEach((pl) => {
+
+                const sk = pinDate(pl.timestamp);
+                const pk = createHash(sk, raw.appversion, raw.appos, pl);
+
+
+                if (pk in aggregates){
+
+                    aggregates[pk].count += pl.count;
+
+                } else {
+
+                    aggregates[pk] = {
+                        ...pl,
+                        pk: raw.pk,
+                        date: sk,
+                        appos: raw.appos,
+                        appversion: raw.appversion,
+                    };
+
+                }
+
+            });
+        }
     });
-};  
+
+    return aggregates;
+}
+
+exports.handler = async (event, context, callback) => {
+
+    const aggregates = aggregateEvents(event);
+
+    for (const aggregate in aggregates) {
+
+        const payload = generatePayload(aggregates[aggregate]);
+        try {
+            await documentClient.update(payload).promise();
+        }catch(err){
+            console.log(err);
+            //TODO: send to dead letter queue
+        }
+    }
+};

--- a/server/aws/lambda/create_metric.js
+++ b/server/aws/lambda/create_metric.js
@@ -19,7 +19,7 @@ exports.handler = async (event, context) => {
     };
 
     // expire after 24 hours
-    const ttl = (Date.now() + 86400000).toString()
+    const ttl = (Math.floor(Date.now()/1000) + 86400).toString();
 
     const params = {
         TableName: process.env.TABLE_NAME,
@@ -34,11 +34,11 @@ exports.handler = async (event, context) => {
                 S: event.body,
             },
         },
-    }
+    };
 
     try {
 
-        const resp = await dynamodb.putItem(params).promise()
+        await dynamodb.putItem(params).promise();
         transactionStatus.statusCode = 200;
         transactionStatus.body = JSON.stringify({ "status": "RECORD CREATED" });
     } catch (err) {

--- a/server/aws/modules/metrics/iam_policies.tf
+++ b/server/aws/modules/metrics/iam_policies.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "aggregate_metrics_put" {
     effect = "Allow"
 
     actions = [
-      "dynamodb:PutItem"
+      "dynamodb:UpdateItem"
     ]
 
     resources = [


### PR DESCRIPTION
Pre-aggregates events that are coming in from the event stream to reduce writes to the aggregate_metrics table
Properly set TTL on raw_metrics folder
Provide proper permissions to the aggregator on the aggregate_metrics table.
