### PR TITLE
fix: attach update policy to aggregator

### DIFF
--- a/server/aws/lambda/aggregate_values.js
+++ b/server/aws/lambda/aggregate_values.js
@@ -4,7 +4,7 @@ const AWS = require("aws-sdk");
 const documentClient = new AWS.DynamoDB.DocumentClient();
 const crypto = require("crypto")
 
-function createHash(sk, appversion, appos, pl)
+function createHash(sk, appversion, appos, pl) {
     return crypto.createHash('md5')
         .update(`${sk}_${pl.region}_${appversion}_${appos}_${pl.identifier}`)
         .digest('hex');

--- a/server/aws/modules/metrics/aggregator_iam.tf
+++ b/server/aws/modules/metrics/aggregator_iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "aggregator" {
-  name = "aggregate_lambda_role"
+  name               = "aggregate_lambda_role"
   assume_role_policy = data.aws_iam_policy_document.service_principal.json
 }
 
@@ -18,7 +18,7 @@ resource "aws_iam_role_policy_attachment" "aggregator_vpc_networking" {
   policy_arn = aws_iam_policy.vpc_networking.arn
 }
 
-resource "aws_iam_role_policy_attachment" "aggregator_raw_metrics_stream_processor" { 
+resource "aws_iam_role_policy_attachment" "aggregator_raw_metrics_stream_processor" {
   role       = aws_iam_role.aggregator.name
   policy_arn = aws_iam_policy.raw_metrics_stream_processor.arn
 }

--- a/server/aws/modules/metrics/aggregator_iam.tf
+++ b/server/aws/modules/metrics/aggregator_iam.tf
@@ -3,6 +3,11 @@ resource "aws_iam_role" "aggregator" {
   assume_role_policy = data.aws_iam_policy_document.service_principal.json
 }
 
+resource "aws_iam_role_policy_attachment" "aggregator_update" {
+  role       = aws_iam_role.aggregator.name
+  policy_arn = aws_iam_policy.aggregate_metrics_update.arn
+}
+
 resource "aws_iam_role_policy_attachment" "aggregator_log_writer" {
   role       = aws_iam_role.aggregator.name
   policy_arn = aws_iam_policy.write_logs.arn

--- a/server/aws/modules/metrics/iam_policies.tf
+++ b/server/aws/modules/metrics/iam_policies.tf
@@ -86,7 +86,7 @@ resource "aws_iam_policy" "write_logs" {
 # vpc_networking
 
 data "aws_iam_policy_document" "vpc_networking" {
-  statement { 
+  statement {
 
     effect = "Allow"
 
@@ -112,7 +112,7 @@ resource "aws_iam_policy" "vpc_networking" {
 # dynamodb_streams
 
 data "aws_iam_policy_document" "raw_metrics_stream_processor" {
-  statement { 
+  statement {
 
     effect = "Allow"
     actions = [

--- a/server/aws/modules/metrics/iam_policies.tf
+++ b/server/aws/modules/metrics/iam_policies.tf
@@ -1,6 +1,6 @@
 # aggregator_metrics_put
 
-data "aws_iam_policy_document" "aggregate_metrics_put" {
+data "aws_iam_policy_document" "aggregate_metrics_update" {
   statement {
     effect = "Allow"
 
@@ -15,10 +15,10 @@ data "aws_iam_policy_document" "aggregate_metrics_put" {
 
 }
 
-resource "aws_iam_policy" "aggregate_metrics_put" {
+resource "aws_iam_policy" "aggregate_metrics_update" {
   name   = "CovidAlertAggregateMetricsPutItem"
   path   = "/"
-  policy = data.aws_iam_policy_document.aggregate_metrics_put.json
+  policy = data.aws_iam_policy_document.aggregate_metrics_update.json
 }
 
 # raw_metrics_put


### PR DESCRIPTION
We had neglected to attach the policy allowing updates of the
aggregation table to the lambda.

Add a curly-brace that had dissapeared.
