### PR TITLE
feat: add private link to SQS/KMS

### DIFF
--- a/server/aws/in-app-metrics.tf
+++ b/server/aws/in-app-metrics.tf
@@ -6,4 +6,5 @@ module "in_app_metrics" {
   role_name               = aws_iam_role.role.name
   lambda_function_runtime = var.lambda-function-runtime
   subnet_ids              = aws_subnet.covidshield_private.*.id
+  privatelink_sg          = aws_security_group.privatelink.id
 }

--- a/server/aws/modules/metrics/aggregator.tf
+++ b/server/aws/modules/metrics/aggregator.tf
@@ -46,6 +46,16 @@ resource "aws_security_group" "aggregate_metrics_sg" {
   }
 }
 
+resource "aws_security_group_rule" "privatelink_metrics_aggregator" {
+  description              = "Security group rule for metricsRetrieval ingress"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = var.privatelink_sg
+  source_security_group_id = aws_security_group.aggregate_metrics_sg.id
+}
+
 resource "aws_cloudwatch_log_group" "metrics" {
   name              = "/aws/lambda/${aws_lambda_function.aggregate_metrics.function_name}"
   retention_in_days = 14

--- a/server/aws/modules/metrics/variables.tf
+++ b/server/aws/modules/metrics/variables.tf
@@ -21,3 +21,7 @@ variable "lambda_function_runtime" {
 variable "subnet_ids" {
   type = set(string)
 }
+
+variable "privatelink_sg" {
+  type = string
+}

--- a/server/aws/networking.tf
+++ b/server/aws/networking.tf
@@ -53,6 +53,18 @@ resource "aws_vpc_endpoint" "kms" {
   subnet_ids = aws_subnet.covidshield_private.*.id
 }
 
+resource "aws_vpc_endpoint" "sqs" {
+  vpc_id              = aws_vpc.covidshield.id
+  vpc_endpoint_type   = "Interface"
+  service_name        = "com.amazonaws.${var.region}.sqs"
+  private_dns_enabled = true
+  security_group_ids = [
+    aws_security_group.privatelink.id,
+  ]
+  subnet_ids = aws_subnet.covidshield_private.*.id
+}
+
+
 resource "aws_vpc_endpoint" "secretsmanager" {
   vpc_id              = aws_vpc.covidshield.id
   vpc_endpoint_type   = "Interface"


### PR DESCRIPTION
Adds a SQS private link and allows the metrics lambda to access the SG that those endpoints are connected to.