### PR TITLE
fix: add DeleteMessage permission

### DIFF
--- a/server/aws/modules/metrics/iam_policies.tf
+++ b/server/aws/modules/metrics/iam_policies.tf
@@ -173,7 +173,8 @@ data "aws_iam_policy_document" "read_write_and_encrypt_deadletter_queue" {
       "kms:GenerateDataKey",
       "kms:Decrypt",
       "sqs:SendMessage",
-      "sqs:ReceiveMessage"
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage"
 
     ]
     resources = [


### PR DESCRIPTION
This PR adds the `sqs:DeleteMessage` permission to the backoff role.

