### PR TITLE
fix: remove the uneeded missing method

### DIFF
--- a/server/aws/lambda/aggregate_values.js
+++ b/server/aws/lambda/aggregate_values.js
@@ -13,7 +13,6 @@ function createHash(sk, appversion, appos, pl) {
 
 function generatePayload(a) {
 
-    const updateCount = readCount(a);
 
     return {
         TableName: "aggregate_metrics",
@@ -47,7 +46,7 @@ function generatePayload(a) {
             ":appos": a.appos,
             ":region": a.region,
             ":identifier": a.identifier,
-            ":count": updateCount,
+            ":count": a.count,
             ':pushnotification': a.pushnotification || '',
             ':frameworkenabled': a.frameworkenabled || '',
             ':state': a.state || '',

--- a/server/aws/modules/metrics/iam_policies.tf
+++ b/server/aws/modules/metrics/iam_policies.tf
@@ -174,7 +174,8 @@ data "aws_iam_policy_document" "read_write_and_encrypt_deadletter_queue" {
       "kms:Decrypt",
       "sqs:SendMessage",
       "sqs:ReceiveMessage",
-      "sqs:DeleteMessage"
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes"
 
     ]
     resources = [


### PR DESCRIPTION
Since we parseInt before we add to the aggregates or update the count it should always be a number and not a string anymore. 
