### PR TITLE
feat: remove ingress and egress for default security group

### DIFF
--- a/server/aws/networking.tf
+++ b/server/aws/networking.tf
@@ -192,6 +192,10 @@ resource "aws_route_table_association" "covidshield" {
 # AWS Security Groups
 ###
 
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.covidshield.id
+}
+
 resource "aws_security_group" "covidshield_key_retrieval" {
   name        = "covidshield-key-retrieval"
   description = "Ingress - CovidShield Key Retrieval App"


### PR DESCRIPTION
Closes #135.

This PR removes the default ingress and egress rules on the default security group for the VPC by adopting it into TF management. As nothing should be using the default security group, this should have no impact.
