### PR TITLE
fix: use asynchronous sdk calls reuse connection

### DIFF
--- a/server/aws/lambda/aggregate_values.js
+++ b/server/aws/lambda/aggregate_values.js
@@ -43,7 +43,7 @@ function generatePayload(a) {
             #state = :state,
             hoursSinceExposureDetectedAt = :hoursSinceExposureDetectedAt, 
             #date = :date
-        ADD metricCount :metricCount`,
+            metricCount = if_not_exists(metricCount, :start) + :metricCount`,
         ExpressionAttributeValues: {
             ':metricCount' : a.metricCount,
             ':appversion' : a.appversion,
@@ -57,6 +57,7 @@ function generatePayload(a) {
             ':state': a.state || '',
             ':hoursSinceExposureDetectedAt': a.hoursSinceExposureDetectedAt || '',
             ':date' : a.date || '',
+            ':start': 0,
         },
         ExpressionAttributeNames: {
             '#region': 'region',

--- a/server/aws/lambda/aggregate_values.js
+++ b/server/aws/lambda/aggregate_values.js
@@ -1,4 +1,4 @@
-d'use strict';
+'use strict';
 
 const AWS = require("aws-sdk");
 

--- a/server/aws/lambda/aggregate_values.js
+++ b/server/aws/lambda/aggregate_values.js
@@ -1,9 +1,20 @@
-'use strict';
+d'use strict';
 
 const AWS = require("aws-sdk");
-const documentClient = new AWS.DynamoDB.DocumentClient();
+
 const sqs = new AWS.SQS({apiVersion: '2012-11-05'});
 const METRIC_VERSION = 2;
+const https = require('https');
+const agent = new https.Agent({
+  keepAlive: true
+});
+
+const documentClient = new AWS.DynamoDB.DocumentClient({
+  httpOptions: {
+    agent
+  }
+});
+
 
 function p(val) { 
     return val || '*';
@@ -115,31 +126,25 @@ function buildDeadLetterMsg(payload, err){
     };
 }
 
-async function sendToDeadLetterQueue(payload, err) {
-    let msg;
-    
-    try{
-        msg = buildDeadLetterMsg(payload,err);
-        await sqs.sendMessage(msg).promise();
-    } catch (sqsErr){
-        console.error(`Failed sending to Dead Letter Queue: ${sqsErr}, failed msg: ${msg}`);
-    }
+function sendToDeadLetterQueue(payload, err) {
+    const msg = buildDeadLetterMsg(payload, err);
+    sqs.sendMessage(msg, (sqsErr, data) => {
+        if (sqsErr) { 
+            console.error(`Failed sending to Dead Letter Queue: ${sqsErr}, failed msg: ${msg}`);
+        }
+    });
 }
 
-exports.handler = async (event, context, callback) => {
+exports.handler =  (event, context, callback) => {
     const aggregates = aggregateEvents(event);
-
     for (const aggregate in aggregates) {
         const payload = generatePayload(aggregates[aggregate]);
-        try {
-
-            await documentClient.update(payload).promise();
-
-        }catch(err){
-
-            console.error(`Failed updating sending to Dead Letter Queue ${err}`);
-            await sendToDeadLetterQueue(payload);
-
-        }
+        documentClient.update(payload, (err, data) => { 
+            if (err){ 
+                console.error(`Failed updating sending to Dead Letter Queue ${err}`);
+                sendToDeadLetterQueue(payload, err);
+            }
+        });
     }
+    callback(null, "Aggregator is complete");
 };

--- a/server/aws/lambda/aggregate_values.js
+++ b/server/aws/lambda/aggregate_values.js
@@ -6,13 +6,13 @@ const sqs = new AWS.SQS({apiVersion: '2012-11-05'});
 const METRIC_VERSION = 2;
 const https = require('https');
 const agent = new https.Agent({
-  keepAlive: true
+    keepAlive: true
 });
 
 const documentClient = new AWS.DynamoDB.DocumentClient({
-  httpOptions: {
-    agent
-  }
+    httpOptions: {
+        agent
+    }
 });
 
 

--- a/server/aws/modules/metrics/aggregator.tf
+++ b/server/aws/modules/metrics/aggregator.tf
@@ -14,6 +14,7 @@ resource "aws_lambda_function" "aggregate_metrics" {
   handler = "aggregate_values.handler"
   runtime = var.lambda_function_runtime
   role    = aws_iam_role.aggregator.arn
+  timeout = 60
 
   vpc_config {
     security_group_ids = [aws_security_group.aggregate_metrics_sg.id]


### PR DESCRIPTION
- Replace synchronous await calls with asynchronous calls
- Reuse a connection between all DynamoDB calls
- Increase timeout for lambda to 1 minute (60 seconds)
- Replace ADD update command with SET as per AWS recommendations