### PR TITLE
fix: move egress block to initial definition

### DIFF
--- a/server/aws/modules/metrics/aggregator.tf
+++ b/server/aws/modules/metrics/aggregator.tf
@@ -49,7 +49,7 @@ resource "aws_security_group" "aggregate_metrics_sg" {
     from_port       = 443
     to_port         = 443
     protocol        = "tcp"
-    prefix_list_ids = [var.privatelink_sg]
+    security_groups = [var.privatelink_sg]
   }
 }
 

--- a/server/aws/modules/metrics/aggregator.tf
+++ b/server/aws/modules/metrics/aggregator.tf
@@ -44,6 +44,13 @@ resource "aws_security_group" "aggregate_metrics_sg" {
     protocol        = "tcp"
     prefix_list_ids = [aws_vpc_endpoint.dynamodb.prefix_list_id]
   }
+
+  egress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    prefix_list_ids = [var.privatelink_sg]
+  }
 }
 
 resource "aws_security_group_rule" "privatelink_metrics_aggregator" {
@@ -54,16 +61,6 @@ resource "aws_security_group_rule" "privatelink_metrics_aggregator" {
   protocol                 = "tcp"
   security_group_id        = var.privatelink_sg
   source_security_group_id = aws_security_group.aggregate_metrics_sg.id
-}
-
-resource "aws_security_group_rule" "privatelink_metrics_aggregator_egress" {
-  description              = "Security group rule for metricsRetrieval egress"
-  type                     = "egress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.aggregate_metrics_sg.id
-  source_security_group_id = var.privatelink_sg
 }
 
 resource "aws_cloudwatch_log_group" "metrics" {

--- a/server/aws/modules/metrics/backoff_retry.tf
+++ b/server/aws/modules/metrics/backoff_retry.tf
@@ -41,6 +41,13 @@ resource "aws_security_group" "backoff_retry_sg" {
     protocol        = "tcp"
     prefix_list_ids = [aws_vpc_endpoint.dynamodb.prefix_list_id]
   }
+
+  egress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    prefix_list_ids = [var.privatelink_sg]
+  }
 }
 
 resource "aws_security_group_rule" "privatelink_metrics_backoff_ingress" {
@@ -51,16 +58,6 @@ resource "aws_security_group_rule" "privatelink_metrics_backoff_ingress" {
   protocol                 = "tcp"
   security_group_id        = var.privatelink_sg
   source_security_group_id = aws_security_group.backoff_retry_sg.id
-}
-
-resource "aws_security_group_rule" "privatelink_metrics_backoff_egress" {
-  description              = "Security group rule for metricsRetrieval egress"
-  type                     = "egress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.backoff_retry_sg.id
-  source_security_group_id = var.privatelink_sg
 }
 
 resource "aws_cloudwatch_log_group" "backoff_log_group" {

--- a/server/aws/modules/metrics/backoff_retry.tf
+++ b/server/aws/modules/metrics/backoff_retry.tf
@@ -46,7 +46,7 @@ resource "aws_security_group" "backoff_retry_sg" {
     from_port       = 443
     to_port         = 443
     protocol        = "tcp"
-    prefix_list_ids = [var.privatelink_sg]
+    security_groups = [var.privatelink_sg]
   }
 }
 


### PR DESCRIPTION
This moves an egress definition between the metrics aggregation lambda security group and the private link security group to the initial definition of the aggregations. We noted that the second definition was never applied.