### PR TITLE
feat: terraform alerting around metrics infrastructure

### DIFF
--- a/server/aws/cloudwatch.tf
+++ b/server/aws/cloudwatch.tf
@@ -518,3 +518,97 @@ resource "aws_cloudwatch_metric_alarm" "route53_submission_health_check" {
     HealthCheckId = aws_route53_health_check.covidshield_key_submission_healthcheck.id
   }
 }
+
+###
+# AWS API Gateway
+###
+
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_errors_above_threshold" {
+  alarm_name          = "metrics-api-gateway-errors-above-threshold"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "5XXError"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.api_gateway_error_threshold
+  alarm_description   = "This metric monitors 500 errors in the metrics API gateway"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    ApiName = aws_api_gateway_rest_api.metrics.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_min_invocations_threshold" {
+  alarm_name          = "metrics-api-gateway-below-minimum-invocations"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Count"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.api_gateway_min_invocations
+  alarm_description   = "This metric monitors minimum API gateway invocations for the metrics API gateway"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    ApiName = aws_api_gateway_rest_api.metrics.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_max_invocations_threshold" {
+  alarm_name          = "metrics-api-gateway-above-maximum-invocations"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Count"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.api_gateway_max_invocations
+  alarm_description   = "This metric monitors maximum API gateway invocations for the metrics API gateway"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    ApiName = aws_api_gateway_rest_api.metrics.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_max_latency_threshold" {
+  alarm_name          = "metrics-api-gateway-above-maximum-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Count"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.api_gateway_max_latency
+  alarm_description   = "This metric monitors maximum API gateway latency for the metrics API gateway"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    ApiName = aws_api_gateway_rest_api.metrics.name
+  }
+}
+
+
+###
+# AWS Lambda
+###
+
+resource "aws_cloudwatch_metric_alarm" "save_metrics_average_duration" {
+  alarm_name          = "save-metrics-average-duration"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = var.save_metrics_max_avg_duration
+  alarm_description   = "This metric monitors average duration for the save_metrics lambda"
+
+  alarm_actions = [aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    FunctionName = aws_lambda_function.metrics.function_name
+  }
+}

--- a/server/aws/in-app-metrics.tf
+++ b/server/aws/in-app-metrics.tf
@@ -8,7 +8,7 @@ module "in_app_metrics" {
   subnet_ids                         = aws_subnet.covidshield_private.*.id
   privatelink_sg                     = aws_security_group.privatelink.id
   warn_topic                         = aws_sns_topic.alert_warning.arn
-  crticial_topic                     = aws_sns_topic.alert_critical.arn
+  critical_topic                     = aws_sns_topic.alert_critical.arn
   raw_metrics_dynamodb_wcu_max       = var.raw_metrics_dynamodb_wcu_max
   aggregate_metrics_dynamodb_wcu_max = var.aggregate_metrics_dynamodb_wcu_max
   aggregate_metrics_max_avg_duration = var.aggregate_metrics_max_avg_duration

--- a/server/aws/in-app-metrics.tf
+++ b/server/aws/in-app-metrics.tf
@@ -1,12 +1,16 @@
 module "in_app_metrics" {
-  region                  = var.region
-  source                  = "./modules/metrics"
-  vpc_id                  = aws_vpc.covidshield.id
-  route_table_id          = aws_vpc.covidshield.main_route_table_id
-  role_name               = aws_iam_role.role.name
-  lambda_function_runtime = var.lambda-function-runtime
-  subnet_ids              = aws_subnet.covidshield_private.*.id
-  privatelink_sg          = aws_security_group.privatelink.id
-  warn_topic              = aws_sns_topic.alert_warning.arn
-  crticial_topic          = aws_sns_topic.alert_critical.arn
+  region                             = var.region
+  source                             = "./modules/metrics"
+  vpc_id                             = aws_vpc.covidshield.id
+  route_table_id                     = aws_vpc.covidshield.main_route_table_id
+  role_name                          = aws_iam_role.role.name
+  lambda_function_runtime            = var.lambda-function-runtime
+  subnet_ids                         = aws_subnet.covidshield_private.*.id
+  privatelink_sg                     = aws_security_group.privatelink.id
+  warn_topic                         = aws_sns_topic.alert_warning.arn
+  crticial_topic                     = aws_sns_topic.alert_critical.arn
+  raw_metrics_dynamodb_wcu_max       = var.raw_metrics_dynamodb_wcu_max
+  aggregate_metrics_dynamodb_wcu_max = var.aggregate_metrics_dynamodb_wcu_max
+  aggregate_metrics_max_avg_duration = var.aggregate_metrics_max_avg_duration
+  backoff_retry_max_avg_duration     = var.backoff_retry_max_avg_duration
 }

--- a/server/aws/in-app-metrics.tf
+++ b/server/aws/in-app-metrics.tf
@@ -7,4 +7,6 @@ module "in_app_metrics" {
   lambda_function_runtime = var.lambda-function-runtime
   subnet_ids              = aws_subnet.covidshield_private.*.id
   privatelink_sg          = aws_security_group.privatelink.id
+  warn_topic              = aws_sns_topic.alert_warning.arn
+  crticial_topic          = aws_sns_topic.alert_critical.arn
 }

--- a/server/aws/mc-variables.tf
+++ b/server/aws/mc-variables.tf
@@ -49,3 +49,24 @@ variable "api_gateway_burst" {
   type    = string
   default = 5000
 }
+
+variable "api_gateway_error_threshold" {
+  type    = string
+}
+
+
+variable "api_gateway_min_invocations" {
+  type    = string
+}
+
+variable "api_gateway_max_invocations" {
+  type    = string
+}
+
+variable "api_gateway_max_latency" {
+  type    = string
+}
+
+variable "save_metrics_max_avg_duration" {
+  type    = string
+}

--- a/server/aws/mc-variables.tf
+++ b/server/aws/mc-variables.tf
@@ -51,22 +51,37 @@ variable "api_gateway_burst" {
 }
 
 variable "api_gateway_error_threshold" {
-  type    = string
+  type = string
 }
 
-
 variable "api_gateway_min_invocations" {
-  type    = string
+  type = string
 }
 
 variable "api_gateway_max_invocations" {
-  type    = string
+  type = string
 }
 
 variable "api_gateway_max_latency" {
-  type    = string
+  type = string
 }
 
 variable "save_metrics_max_avg_duration" {
-  type    = string
+  type = string
+}
+
+variable "raw_metrics_dynamodb_wcu_max" {
+  type = string
+}
+
+variable "aggregate_metrics_dynamodb_wcu_max" {
+  type = string
+}
+
+variable "aggregate_metrics_max_avg_duration" {
+  type = string
+}
+
+variable "backoff_retry_max_avg_duration" {
+  type = string
 }

--- a/server/aws/modules/metrics/alerts.tf
+++ b/server/aws/modules/metrics/alerts.tf
@@ -1,0 +1,75 @@
+###
+# AWS DynamoDB
+###
+
+resource "aws_cloudwatch_metric_alarm" "raw_metrics_dynamodb_wcu" {
+  alarm_name          = "raw-metrics-dynamodb-wcu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ConsumedWriteCapacityUnits"
+  namespace           = "AWS/DynamoDB"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.raw_metrics_dynamodb_wcu_max
+  alarm_description   = "This metric monitors maximum write capacity units for the raw_metrics table"
+
+  alarm_actions = [var.critical_topic]
+  dimensions = {
+    TableName = aws_dynamodb_table.raw_metrics.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "aggregate_metrics_dynamodb_wcu" {
+  alarm_name          = "aggregate-metrics-dynamodb-wcu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ConsumedWriteCapacityUnits"
+  namespace           = "AWS/DynamoDB"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.aggregate_metrics_dynamodb_wcu_max
+  alarm_description   = "This metric monitors maximum write capacity units for the aggregate_metrics table"
+
+  alarm_actions = [var.critical_topic]
+  dimensions = {
+    TableName = aws_dynamodb_table.aggregate_metrics.name
+  }
+}
+
+###
+# AWS Lambda
+###
+
+resource "aws_cloudwatch_metric_alarm" "aggregate_metrics_average_duration" {
+  alarm_name          = "aggregate-metrics-average-duration"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = var.aggregate_metrics_max_avg_duration
+  alarm_description   = "This metric monitors average duration for the aggregate_metrics lambda"
+
+  alarm_actions = [var.critical_topic]
+  dimensions = {
+    FunctionName = aws_lambda_function.aggregate_metrics.function_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "backoff_retry_average_duration" {
+  alarm_name          = "save-metrics-average-duration"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = var.backoff_retry_max_avg_duration
+  alarm_description   = "This metric monitors average duration for the backoff_retry lambda"
+
+  alarm_actions = [var.critical_topic]
+  dimensions = {
+    FunctionName = aws_lambda_function.backoff_retry.function_name
+  }
+}

--- a/server/aws/modules/metrics/variables.auto.tfvars
+++ b/server/aws/modules/metrics/variables.auto.tfvars
@@ -1,0 +1,4 @@
+raw_metrics_dynamodb_wcu_max = 300
+aggregate_metrics_dynamodb_wcu_max = 300
+aggregate_metrics_max_avg_duration = 3000
+backoff_retry_max_avg_duration = 3000

--- a/server/aws/modules/metrics/variables.auto.tfvars
+++ b/server/aws/modules/metrics/variables.auto.tfvars
@@ -1,4 +1,0 @@
-raw_metrics_dynamodb_wcu_max = 300
-aggregate_metrics_dynamodb_wcu_max = 300
-aggregate_metrics_max_avg_duration = 3000
-backoff_retry_max_avg_duration = 3000

--- a/server/aws/modules/metrics/variables.tf
+++ b/server/aws/modules/metrics/variables.tf
@@ -25,3 +25,27 @@ variable "subnet_ids" {
 variable "privatelink_sg" {
   type = string
 }
+
+variable "warn_topic" {
+  type = string
+}
+
+variable "critical_topic" {
+  type = string
+}
+
+variable "raw_metrics_dynamodb_wcu_max" {
+  type = string
+}
+
+variable "aggregate_metrics_dynamodb_wcu_max" {
+  type = string
+}
+
+variable "aggregate_metrics_max_avg_duration" {
+  type = string
+}
+
+variable "backoff_retry_max_avg_duration" {
+  type = string
+}

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -99,6 +99,11 @@ enable_test_tools = true
 api_gateway_error_threshold = 100
 api_gateway_min_invocations = 100
 api_gateway_max_invocations = 10000
-api_gateway_max_latency = 5000
+api_gateway_max_latency     = 5000
 
-save_metrics_max_avg_duration = 3000
+raw_metrics_dynamodb_wcu_max       = 300
+aggregate_metrics_dynamodb_wcu_max = 300
+
+save_metrics_max_avg_duration      = 3000
+aggregate_metrics_max_avg_duration = 3000
+backoff_retry_max_avg_duration     = 3000

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -96,8 +96,8 @@ enable_test_tools = true
 # API Gateway & Lambda Alarms
 ###
 
-api_gateway_error_threshold = 100
-api_gateway_min_invocations = 100
+api_gateway_error_threshold = 95
+api_gateway_min_invocations = 0
 api_gateway_max_invocations = 10000
 api_gateway_max_latency     = 5000
 
@@ -105,5 +105,5 @@ raw_metrics_dynamodb_wcu_max       = 300
 aggregate_metrics_dynamodb_wcu_max = 300
 
 save_metrics_max_avg_duration      = 3000
-aggregate_metrics_max_avg_duration = 3000
+aggregate_metrics_max_avg_duration = 60000
 backoff_retry_max_avg_duration     = 3000

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -91,3 +91,14 @@ unclaimed_one_time_code_total_warn     = 250
 unclaimed_one_time_code_total_critical = 400
 
 enable_test_tools = true
+
+###
+# API Gateway & Lambda Alarms
+###
+
+api_gateway_error_threshold = 100
+api_gateway_min_invocations = 100
+api_gateway_max_invocations = 10000
+api_gateway_max_latency = 5000
+
+save_metrics_max_avg_duration = 3000


### PR DESCRIPTION
This PR adds the terraform for alerts around our metrics infrastructure. These include:

### API gateway 
 - More then X 500 error
 - under X invocations a minute
 - over X invocations a minute

### DynamoDB 
 - WCU per minute for raw_metrics 
 - WCU per minute for aggregate_metrics
 
###  Lambda 
 - invocation time for raw_metrics
 - invocation time for aggregate_metrics

Threshold adjustments can be made to 

server/aws/variables.auto.tfvars
