### PR TITLE
feat: Add ops dashboard for metrics service

### DIFF
--- a/server/aws/in-app-metrics.tf
+++ b/server/aws/in-app-metrics.tf
@@ -13,4 +13,5 @@ module "in_app_metrics" {
   aggregate_metrics_dynamodb_wcu_max = var.aggregate_metrics_dynamodb_wcu_max
   aggregate_metrics_max_avg_duration = var.aggregate_metrics_max_avg_duration
   backoff_retry_max_avg_duration     = var.backoff_retry_max_avg_duration
+  service_name                       = var.service_name
 }

--- a/server/aws/modules/codedeploy/variables.tf
+++ b/server/aws/modules/codedeploy/variables.tf
@@ -24,12 +24,12 @@ variable "ecs_service_name" {
 }
 
 variable "lb_listener_arns" {
-  type        = list
+  type        = list(any)
   description = "List of Amazon Resource Names (ARNs) of the load balancer listeners."
 }
 
 variable "test_lb_listener_arns" {
-  type        = list
+  type        = list(any)
   description = "List of Amazon Resource Names (ARNs) of the test load balancer listeners."
 }
 

--- a/server/aws/modules/metrics/dashboard.tf
+++ b/server/aws/modules/metrics/dashboard.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_dashboard" "metrics_ops_dashboard" {
             "height": 6,
             "properties": {
                 "metrics": [
-                    [ "AWS/ApiGateway", "4XXError", "ApiName", "${var.service_name}", "Resource", "/${var.service_name}, "Stage", "production", "Method", "POST" ],
+                    [ "AWS/ApiGateway", "4XXError", "ApiName", "${var.service_name}", "Resource", "/${var.service_name}", "Stage", "production", "Method", "POST" ],
                     [ ".", "Count", ".", ".", ".", ".", ".", ".", ".", ".", { "visible": false } ],
                     [ ".", "5XXError", ".", ".", ".", ".", ".", ".", ".", "." ]
                 ],

--- a/server/aws/modules/metrics/dashboard.tf
+++ b/server/aws/modules/metrics/dashboard.tf
@@ -1,0 +1,119 @@
+resource "aws_cloudwatch_dashboard" "metrics_ops_dashboard" {
+  dashboard_name = "MetricsOps"
+
+  dashboard_body = <<EOF
+{
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 3,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/DynamoDB", "ConsumedWriteCapacityUnits", "TableName", "${aws_dynamodb_table.aggregate_metrics.name}" ],
+                    [ ".", "ConsumedReadCapacityUnits", ".", "${aws_dynamodb_table.raw_metrics.name}" ],
+                    [ ".", "ConsumedWriteCapacityUnits", ".", "." ],
+                    [ "AWS/ApiGateway", "Count", "ApiName", "${var.service_name}", "Resource", "/${var.service_name}", "Stage", "production", "Method", "POST" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 60,
+                "title": "Metrics - Dynamodb"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 9,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/ApiGateway", "4XXError", "ApiName", "${var.service_name}", "Resource", "/${var.service_name}, "Stage", "production", "Method", "POST" ],
+                    [ ".", "Count", ".", ".", ".", ".", ".", ".", ".", ".", { "visible": false } ],
+                    [ ".", "5XXError", ".", ".", ".", ".", ".", ".", ".", "." ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 60,
+                "title": "APIGW - 5xx & 4xx errors"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 0,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/ApiGateway", "Count", "ApiName", "${var.service_name}", "Resource", "/${var.service_name}", "Stage", "production", "Method", "POST" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "stat": "Sum",
+                "period": 60,
+                "title": "API Gateway Count",
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "visible": false,
+                            "label": "Alarm",
+                            "value": 35000
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 0,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ "AWS/ApiGateway", "Count", "ApiName", "${var.service_name}", "Resource", "/${var.service_name}", "Stage", "production", "Method", "POST" ],
+                    [ ".", "5XXError", ".", ".", ".", ".", ".", ".", ".", "." ],
+                    [ ".", "4XXError", ".", ".", ".", ".", ".", ".", ".", "." ]
+                ],
+                "view": "singleValue",
+                "region": "ca-central-1",
+                "period": 60,
+                "singleValueFullPrecision": true,
+                "stacked": false,
+                "stat": "Sum",
+                "setPeriodToTimeRange": true,
+                "title": "Total for period"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 6,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "AWS/Lambda", "Errors", "FunctionName", "${aws_lambda_function.aggregate_metrics.function_name}" ],
+                    [ "...", "${var.service_name}"]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ca-central-1",
+                "title": "Lambda Errors",
+                "stat": "Sum",
+                "period": 300
+            }
+        }
+    ]
+}
+EOF
+}

--- a/server/aws/modules/metrics/ec2_data_module.tf
+++ b/server/aws/modules/metrics/ec2_data_module.tf
@@ -1,8 +1,8 @@
 module "metrics_data_vm" {
-  source          = "github.com/cds-snc/terraform-ec2-module?ref=v1.0.1"
-  name            = "metrics-data-vm"
-  auto_public_ip  = true
-  ssh_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCszlBXAE+FuP4l3Srh1KDfUzmx1sUy4KW5+khfCLMf6LQVl0ZxrBc82XrXo7s5eWKw7n+XR16Sa3hh4S6ZusCVsKnPkCqvyhad7K+IOxDjAzUBugrZcsTml1Qxz9Yb0ELJa3gqU230Jfim6Sd2fGHxzw8S06uKbgJ6ZmZnSPqi3RfxQj84w83ZW7Ubh7HyNF0Jr2O9VlEGqBAhqxLpheRU4+G/g1UrIAlMtcoVM1yaPkxmKPzCU2a0mY2IpWc2I8VegPXX2Jotkjxi3Ju8omnCvTENH8zD/uF0Pz8H1fh/dWYHeZfYJRh+j5m5FB0CM+I5cL+vqgMx9eiABFgZmDBx"
+  source         = "github.com/cds-snc/terraform-ec2-module?ref=v1.0.1"
+  name           = "metrics-data-vm"
+  auto_public_ip = true
+  ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCszlBXAE+FuP4l3Srh1KDfUzmx1sUy4KW5+khfCLMf6LQVl0ZxrBc82XrXo7s5eWKw7n+XR16Sa3hh4S6ZusCVsKnPkCqvyhad7K+IOxDjAzUBugrZcsTml1Qxz9Yb0ELJa3gqU230Jfim6Sd2fGHxzw8S06uKbgJ6ZmZnSPqi3RfxQj84w83ZW7Ubh7HyNF0Jr2O9VlEGqBAhqxLpheRU4+G/g1UrIAlMtcoVM1yaPkxmKPzCU2a0mY2IpWc2I8VegPXX2Jotkjxi3Ju8omnCvTENH8zD/uF0Pz8H1fh/dWYHeZfYJRh+j5m5FB0CM+I5cL+vqgMx9eiABFgZmDBx"
   # read_dynamodb   = true
   # dynamodb_tables = [ aws_dynamodb_table.raw_metrics.stream_arn ]
 }

--- a/server/aws/modules/metrics/variables.tf
+++ b/server/aws/modules/metrics/variables.tf
@@ -49,3 +49,7 @@ variable "aggregate_metrics_max_avg_duration" {
 variable "backoff_retry_max_avg_duration" {
   type = string
 }
+
+variable "service_name" {
+  type = string
+}


### PR DESCRIPTION
Closes https://github.com/cds-snc/covid-alert-server-staging-terraform/issues/161. This PR creates a dashboard around operation metrics for the metrics collection service. It includes

- Total API calls for a 3 hour period
- number of 5XX errors
- number of 403 errors
- API calls over time
- 5xx and 403 errors over time
- Read and Write capacity units for raw_metrics and aggregate_metrics table
- Count of Lambda errors over time