### PR TITLE
feat: add a feature flag for count alarms

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Terraform security scan
         uses: triat/terraform-security-scan@5f54224e1192fa468b93bcaecb5253679b828c8e
         with:
-          tfsec_version: "v0.38.6"
+          tfsec_version: "v0.39.21"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: false

--- a/server/aws/cloudwatch.tf
+++ b/server/aws/cloudwatch.tf
@@ -558,6 +558,7 @@ resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_min_invocations_thre
 }
 
 resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_max_invocations_threshold" {
+  count               = var.feature_count_alarms ? 1 : 0
   alarm_name          = "metrics-api-gateway-above-maximum-invocations"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"

--- a/server/aws/in-app-metrics.tf
+++ b/server/aws/in-app-metrics.tf
@@ -14,4 +14,5 @@ module "in_app_metrics" {
   aggregate_metrics_max_avg_duration = var.aggregate_metrics_max_avg_duration
   backoff_retry_max_avg_duration     = var.backoff_retry_max_avg_duration
   service_name                       = var.service_name
+  feature_count_alarms               = var.feature_count_alarms
 }

--- a/server/aws/modules/metrics/alerts.tf
+++ b/server/aws/modules/metrics/alerts.tf
@@ -3,6 +3,7 @@
 ###
 
 resource "aws_cloudwatch_metric_alarm" "raw_metrics_dynamodb_wcu" {
+  count               = var.feature_count_alarms ? 1 : 0
   alarm_name          = "raw-metrics-dynamodb-wcu"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
@@ -20,6 +21,7 @@ resource "aws_cloudwatch_metric_alarm" "raw_metrics_dynamodb_wcu" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "aggregate_metrics_dynamodb_wcu" {
+  count               = var.feature_count_alarms ? 1 : 0
   alarm_name          = "aggregate-metrics-dynamodb-wcu"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"

--- a/server/aws/modules/metrics/variables.tf
+++ b/server/aws/modules/metrics/variables.tf
@@ -53,3 +53,7 @@ variable "backoff_retry_max_avg_duration" {
 variable "service_name" {
   type = string
 }
+
+variable "feature_count_alarms" {
+  type = bool
+}

--- a/server/aws/s3.tf
+++ b/server/aws/s3.tf
@@ -2,6 +2,10 @@
 # AWS S3 bucket - Exposure config
 ###
 resource "aws_s3_bucket" "exposure_config" {
+
+  # Versioning on this resource is handled through git
+  # tfsec:ignore:AWS077
+
   bucket = "covid-shield-exposure-config-${var.environment}"
   server_side_encryption_configuration {
     rule {
@@ -46,6 +50,10 @@ POLICY
 ###
 
 resource "aws_s3_bucket" "firehose_waf_logs" {
+
+  # Don't need to version these they should expire and are ephemeral
+  # tfsec:ignore:AWS077
+
   bucket = "covid-shield-${var.environment}-waf-logs"
   acl    = "private"
   server_side_encryption_configuration {
@@ -73,6 +81,10 @@ resource "aws_s3_bucket" "firehose_waf_logs" {
 # AWS S3 bucket - cloudfront log target
 ###
 resource "aws_s3_bucket" "cloudfront_logs" {
+
+  # Don't need to version these they should expire and are ephemeral
+  # tfsec:ignore:AWS077
+
   bucket = "covid-shield-${var.environment}-cloudfront-logs"
   server_side_encryption_configuration {
     rule {

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -73,8 +73,9 @@ rds_server_instance_class    = "db.t3.small"
 ###
 # Feature Flags
 ###
-feature_redis  = true
-feature_shield = true
+feature_redis        = true
+feature_shield       = true
+feature_count_alarms = false
 
 
 ###

--- a/server/aws/variables.tf
+++ b/server/aws/variables.tf
@@ -210,6 +210,10 @@ variable "feature_shield" {
   type = bool
 }
 
+variable "feature_count_alarms" {
+  type = bool
+}
+
 
 ###
 # Testing Tools


### PR DESCRIPTION
Adds a feature flag to turn off alarms that have a tendency to go off
during the collection of debug metrics.

The reason for turning this off versus just increasing metric count is
that we have so far been pretty bad about being able to predict traffic
patterns with debug metrics turned on.

We should be able to determine failure of the metrics collection service
through other means such as an increase in errors or a drop off of
invocations.

closes #193 
