### PR TITLE
fix: ruse proper metric for alarm

### DIFF
--- a/server/aws/cloudwatch.tf
+++ b/server/aws/cloudwatch.tf
@@ -579,7 +579,7 @@ resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_max_latency_threshol
   alarm_name          = "metrics-api-gateway-above-maximum-latency"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
-  metric_name         = "Count"
+  metric_name         = "Latency"
   namespace           = "AWS/ApiGateway"
   period              = "60"
   statistic           = "Sum"

--- a/server/aws/cloudwatch.tf
+++ b/server/aws/cloudwatch.tf
@@ -582,7 +582,7 @@ resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_max_latency_threshol
   metric_name         = "Latency"
   namespace           = "AWS/ApiGateway"
   period              = "60"
-  statistic           = "Sum"
+  extended_statistic  = "p95"
   threshold           = var.api_gateway_max_latency
   alarm_description   = "This metric monitors maximum API gateway latency for the metrics API gateway"
 

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -100,7 +100,7 @@ enable_test_tools = true
 api_gateway_error_threshold = 95
 api_gateway_min_invocations = 0
 api_gateway_max_invocations = 10000
-api_gateway_max_latency     = 5000
+api_gateway_max_latency     = 600
 
 raw_metrics_dynamodb_wcu_max       = 300
 aggregate_metrics_dynamodb_wcu_max = 300


### PR DESCRIPTION
Use the latency metric for the latency alarm

Closes #197