### PR TITLE
fix: use valid s3 bucket names

### DIFF
--- a/server/aws/modules/metrics/s3.tf
+++ b/server/aws/modules/metrics/s3.tf
@@ -1,5 +1,7 @@
 resource "random_string" "bucket_random_id" { 
   length = 5
+  upper  = false
+  number = false
 }
 
 data "aws_caller_identity" "current" {}
@@ -9,7 +11,7 @@ resource "aws_s3_bucket" "masked_metrics" {
   # Versioning on this resource is handled through git
   # tfsec:ignore:AWS077
 
-  bucket = "masked_metrics-${random_string.bucket_random_id.result}-${var.environment}"
+  bucket = "masked_metrics_${random_string.bucket_random_id.result}_${var.environment}"
 
   server_side_encryption_configuration {
     rule {
@@ -21,7 +23,7 @@ resource "aws_s3_bucket" "masked_metrics" {
 
   logging {
     target_bucket = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
-    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/masked_metrics-${random_string.bucket_random_id.result}-${var.environment}/"
+    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/masked_metrics_${random_string.bucket_random_id.result}_${var.environment}/"
   }
 
 }
@@ -31,7 +33,7 @@ resource "aws_s3_bucket" "unmasked_metrics" {
   # Versioning on this resource is handled through git
   # tfsec:ignore:AWS077
 
-  bucket = "masked_metrics-${random_string.bucket_random_id.result}-${var.environment}"
+  bucket = "masked_metrics_${random_string.bucket_random_id.result}_${var.environment}"
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -42,7 +44,7 @@ resource "aws_s3_bucket" "unmasked_metrics" {
 
   logging {
     target_bucket = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
-    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/masked-metrics-${random_string.bucket_random_id.result}-${var.environment}/"
+    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/masked_metrics_${random_string.bucket_random_id.result}_${var.environment}/"
   }
 
 }


### PR DESCRIPTION
Use valid s3 bucket names which caused the last apply to fail with the following error: 

>Error: Error validating S3 bucket name: only lowercase alphanumeric characters and hyphens allowed in "masked_metrics-mV_U1-***"
