### PR TITLE
fix: use hyphens not underscores in s3 name

### DIFF
--- a/server/aws/modules/metrics/s3.tf
+++ b/server/aws/modules/metrics/s3.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket" "masked_metrics" {
   # Versioning on this resource is handled through git
   # tfsec:ignore:AWS077
 
-  bucket = "masked_metrics_${random_string.bucket_random_id.result}_${var.environment}"
+  bucket = "masked-metrics-${random_string.bucket_random_id.result}-${var.environment}"
 
   server_side_encryption_configuration {
     rule {
@@ -24,7 +24,7 @@ resource "aws_s3_bucket" "masked_metrics" {
 
   logging {
     target_bucket = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
-    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/masked_metrics_${random_string.bucket_random_id.result}_${var.environment}/"
+    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/masked-metrics-${random_string.bucket_random_id.result}-${var.environment}/"
   }
 
 }
@@ -34,7 +34,7 @@ resource "aws_s3_bucket" "unmasked_metrics" {
   # Versioning on this resource is handled through git
   # tfsec:ignore:AWS077
 
-  bucket = "masked_metrics_${random_string.bucket_random_id.result}_${var.environment}"
+  bucket = "masked-metrics-${random_string.bucket_random_id.result}-${var.environment}"
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -45,7 +45,7 @@ resource "aws_s3_bucket" "unmasked_metrics" {
 
   logging {
     target_bucket = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
-    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/masked_metrics_${random_string.bucket_random_id.result}_${var.environment}/"
+    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/masked-metrics-${random_string.bucket_random_id.result}-${var.environment}/"
   }
 
 }


### PR DESCRIPTION
Apparently I forgot the difference between a hyphen and an underscore, this PR fixes that problem.
