### PR TITLE
fix: give metric buckets unique names

### DIFF
--- a/server/aws/modules/metrics/s3.tf
+++ b/server/aws/modules/metrics/s3.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket" "unmasked_metrics" {
   # Versioning on this resource is handled through git
   # tfsec:ignore:AWS077
 
-  bucket = "masked-metrics-${random_string.bucket_random_id.result}-${var.environment}"
+  bucket = "unmasked-metrics-${random_string.bucket_random_id.result}-${var.environment}"
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
@@ -45,7 +45,7 @@ resource "aws_s3_bucket" "unmasked_metrics" {
 
   logging {
     target_bucket = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
-    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/masked-metrics-${random_string.bucket_random_id.result}-${var.environment}/"
+    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/unmasked-metrics-${random_string.bucket_random_id.result}_${var.environment}/"
   }
 
 }


### PR DESCRIPTION
Gives both s3 buckets for csv metrics unique names, not sure this will fully pass when applying as we also had a lambda error.
