### PR TITLE
fix: lambda deployment

### DIFF
--- a/server/aws/modules/metrics/create_csv.tf
+++ b/server/aws/modules/metrics/create_csv.tf
@@ -5,10 +5,10 @@ locals {
 resource "aws_lambda_function" "unmasked_metrics" {
   function_name = "unmasked_metrics"
 
-  image_uri = local.image_uri
+  package_type = "Image"
+  image_uri    = local.image_uri
 
-  runtime = var.lambda_function_runtime
-  role    = aws_iam_role.backoff.arn
+  role = aws_iam_role.backoff.arn
 
   vpc_config {
     security_group_ids = [aws_security_group.metrics_csv_sg.id]
@@ -25,10 +25,10 @@ resource "aws_lambda_function" "unmasked_metrics" {
 resource "aws_lambda_function" "masked_metrics" {
   function_name = "masked_metrics"
 
-  image_uri = local.image_uri
+  package_type = "Image"
+  image_uri    = local.image_uri
 
-  runtime = var.lambda_function_runtime
-  role    = aws_iam_role.backoff.arn
+  role = aws_iam_role.backoff.arn
 
   vpc_config {
     security_group_ids = [aws_security_group.metrics_csv_sg.id]

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -100,7 +100,7 @@ enable_test_tools = true
 api_gateway_error_threshold = 95
 api_gateway_min_invocations = 0
 api_gateway_max_invocations = 10000
-api_gateway_max_latency     = 600
+api_gateway_max_latency     = 3000
 
 raw_metrics_dynamodb_wcu_max       = 300
 aggregate_metrics_dynamodb_wcu_max = 300


### PR DESCRIPTION
- Changes to (un)+masked_metrics
  - Removed `runtime` from lambdas
  - Added `package_type` = `Image` as it defaults to `Zip`
- Increased API GW Latency alarm so staging isn't constantly pinging

*Please Note:* lambda metrics have already been applied in staging

Closes #208
Closes #207
