### PR TITLE
fix: Terraform pipeline `Check Success` and bump `tfsec`

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -102,11 +102,10 @@ jobs:
             })
 
       - name: Check Success
-        if:  ${{ ( success()  ||  failure() ) && ( steps.fmt.outputs.exit_code  == 1 || steps.plan.outputs.exit_code == 1 ) }}
+        if: ${{ steps.fmt.outcome == 'failure' || steps.plan.outcome == 'failure'  }}
         run: |
-          echo steps.fmt.outcome ${{ steps.fmt.outcome }}
-          echo steps.plan.outcome ${{ steps.plan.outcome }}
-          echo "(${{ steps.fmt.outcome }} == failure || ${{ steps.plan.outcome }} == failure)"
+          echo "steps.fmt.outcome == ${{ steps.fmt.outcome }}"
+          echo "steps.plan.outcome == ${{ steps.plan.outcome }}"
           exit 1
 
   terraform-apply:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@5f54224e1192fa468b93bcaecb5253679b828c8e
+        uses: triat/terraform-security-scan@f14a5d4c004bc150b5c4e56d7a9b4784a17123c8  # v.2.2.1
         with:
-          tfsec_version: "v0.39.21"
+          tfsec_version: "v0.39.29"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: false
@@ -102,7 +102,7 @@ jobs:
             })
 
       - name: Check Success
-        if: ${{ steps.fmt.outcome == 'failure' || steps.plan.outcome == 'failure'  }}
+        if: ${{ steps.fmt.outcome == 'failure' || steps.plan.outcome == 'failure' }}
         run: |
           echo "steps.fmt.outcome == ${{ steps.fmt.outcome }}"
           echo "steps.plan.outcome == ${{ steps.plan.outcome }}"

--- a/server/aws/.terraform.lock.hcl
+++ b/server/aws/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   version = "2.1.0"
   hashes = [
     "h1:Rjd4bHMA69V+16tiriAUTW8vvqoljzNLmEaRBCgzpUs=",
+    "h1:f3WXKM/FBu5EMY6j2BGt982hzVMNicrxTyEAz5EsrOU=",
     "zh:033279ecbf60f565303222e9a6d26b50fdebe43aa1c6e8f565f09bb64d67c3fd",
     "zh:0af998e42eb421c92e87202df5bfee436b3cfe553214394f08d786c72a9e3f70",
     "zh:1183b661c692f38409a61eefb5d412167c246fcd9e49d4d61d6d910012d206ba",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.37"
   hashes = [
     "h1:RvLGIfRZfbzY58wUja9B6CvGdgVVINy7zLVBdLqIelA=",
+    "h1:Tf6Os+utUxE8rEr/emCXLFEDdCb0Y6rsN4Ee84+aDCQ=",
     "zh:064c9b21bcd69be7a8631ccb3eccb8690c6a9955051145920803ef6ce6fc06bf",
     "zh:277dd05750187a41282cf6e066e882eac0dd0056e3211d125f94bf62c19c4b8b",
     "zh:47050211f72dcbf3d99c82147abd2eefbb7238efb94d5188979f60de66c8a3df",
@@ -41,6 +43,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
@@ -60,6 +63,7 @@ provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
     "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
     "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",

--- a/server/aws/.tfsec/config.yml
+++ b/server/aws/.tfsec/config.yml
@@ -1,0 +1,3 @@
+---
+exclude:
+  - AWS079  # Data VM will be removed once CSV ETL Lambda PR lands

--- a/server/aws/ecr.tf
+++ b/server/aws/ecr.tf
@@ -5,7 +5,7 @@ locals {
 resource "aws_ecr_repository" "repository" {
   for_each             = toset(local.image_names)
   name                 = "covid-server/${each.value}"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "MUTABLE" # tfsec:ignore:AWS078  latest tags are used in Staging
 
   image_scanning_configuration {
     scan_on_push = true

--- a/server/aws/modules/metrics/ecr.tf
+++ b/server/aws/modules/metrics/ecr.tf
@@ -1,7 +1,7 @@
 
 resource "aws_ecr_repository" "create_csv" {
   name                 = "covid-server/metrics-server"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "MUTABLE"  # tfsec:ignore:AWS078  `latest` tags are used in Staging
 
   image_scanning_configuration {
     scan_on_push = true


### PR DESCRIPTION
Fixes:
- Pipeline `Check Success` now fails if format/plan fails.
- Updates `tfsec` to latest version and GitHub Action.
- Updates Terraform lock (generated by yesterday's revert of #212)

Closes #78 