### PR TITLE
feat: add vim to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ ARG TFSEC_CHECKSUM
 
 # Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends awscli ca-certificates curl git gnupg2 jq make nano openssh-client zsh \
+    && apt-get -y install --no-install-recommends awscli ca-certificates curl git gnupg2 jq make openssh-client vim zsh \
     && apt-get autoremove -y && apt-get clean -y 
 
 # Install Terraform


### PR DESCRIPTION
This will let us use our local `git config core.editor "vim"` setting in the devcontainer.