### PR TITLE
fix: increase max length of metrics appversion

### DIFF
--- a/server/aws/models/metrics.json
+++ b/server/aws/models/metrics.json
@@ -23,7 +23,7 @@
     "appversion": {
       "type": "string",
       "minLength": 0,
-      "maxLength": 5,
+      "maxLength": 10,
       "title": "App Version Schema",
       "default": "null"
     },


### PR DESCRIPTION
The API gateway is rejecting metric payloads with an appversion that is longer
then 5 characters.

This allows for a 10 character appversion in the payload.