### PR TITLE
feat: Migrate SMS and KMS Key to TG Repo

### DIFF
--- a/server/aws/modules/metrics/.terraform.lock.hcl
+++ b/server/aws/modules/metrics/.terraform.lock.hcl
@@ -1,9 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.27.0"
-  constraints = "~> 3.21"
+  version = "3.27.0"
   hashes = [
     "h1:lJaA23rrNSgLEumcW7Y0KKvno5isVVNNIEV5pT92O8E=",
     "zh:2986eb5a1ffbb0336c6390aad533b62efc832aa8aa5460d523e1f2daa4f42f79",

--- a/server/aws/modules/metrics/aggregator.tf
+++ b/server/aws/modules/metrics/aggregator.tf
@@ -23,7 +23,7 @@ resource "aws_lambda_function" "aggregate_metrics" {
 
   environment {
     variables = {
-      DEAD_LETTER_QUEUE_URL = aws_sqs_queue.aggregation_lambda_dead_letter.id
+      DEAD_LETTER_QUEUE_URL = data.aws_sqs_queue.aggregation_lambda_dead_letter.id
     }
   }
 }

--- a/server/aws/modules/metrics/backoff_retry.tf
+++ b/server/aws/modules/metrics/backoff_retry.tf
@@ -21,13 +21,13 @@ resource "aws_lambda_function" "backoff_retry" {
 
   environment {
     variables = {
-      DEAD_LETTER_QUEUE_URL = aws_sqs_queue.aggregation_lambda_dead_letter.id
+      DEAD_LETTER_QUEUE_URL = data.aws_sqs_queue.aggregation_lambda_dead_letter.id
     }
   }
 }
 
 resource "aws_lambda_event_source_mapping" "dead_letters" {
-  event_source_arn = aws_sqs_queue.aggregation_lambda_dead_letter.arn
+  event_source_arn = data.aws_sqs_queue.aggregation_lambda_dead_letter.arn
   function_name    = aws_lambda_function.backoff_retry.arn
 }
 

--- a/server/aws/modules/metrics/iam_policies.tf
+++ b/server/aws/modules/metrics/iam_policies.tf
@@ -175,8 +175,8 @@ data "aws_iam_policy_document" "write_and_encrypt_deadletter_queue" {
 
     ]
     resources = [
-      aws_kms_key.metrics_key.arn,
-      aws_sqs_queue.aggregation_lambda_dead_letter.arn
+      data.aws_kms_key.metrics_key.arn,
+      data.aws_sqs_queue.aggregation_lambda_dead_letter.arn
     ]
 
   }
@@ -204,8 +204,8 @@ data "aws_iam_policy_document" "read_write_and_encrypt_deadletter_queue" {
 
     ]
     resources = [
-      aws_kms_key.metrics_key.arn,
-      aws_sqs_queue.aggregation_lambda_dead_letter.arn
+      data.aws_kms_key.metrics_key.arn,
+      data.aws_sqs_queue.aggregation_lambda_dead_letter.arn
     ]
 
   }

--- a/server/aws/modules/metrics/kms.tf
+++ b/server/aws/modules/metrics/kms.tf
@@ -1,5 +1,0 @@
-
-resource "aws_kms_key" "metrics_key" {
-  description         = "Metrics key"
-  enable_key_rotation = true
-}

--- a/server/aws/modules/metrics/sqs.tf
+++ b/server/aws/modules/metrics/sqs.tf
@@ -1,6 +1,7 @@
-resource "aws_sqs_queue" "aggregation_lambda_dead_letter" {
-  name                              = "aggregation-lambda-dead-letter-queue"
-  kms_master_key_id                 = aws_kms_key.metrics_key.arn
-  kms_data_key_reuse_period_seconds = 86400
-  message_retention_seconds         = 1209600
+data "aws_sqs_queue" "aggregation_lambda_dead_letter" {
+  name = "aggregation-lambda-dead-letter-queue"
+}
+
+data "aws_kms_key" "metrics_key" {
+  key_id = "arn:aws:kms:ca-central-1:005133826942:key/47379609-95bb-4691-a3d0-7e70bb8d8684"
 }


### PR DESCRIPTION
Replace SQS and KMS with Data Lookups as state is now managed in TG Repo

Please note this should not delete the SQS and KMS or modify other resources (other then deployment of lambdas).

