### PR TITLE
feat: add KMS key alias for easier data lookup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,12 @@
 		"SHELL": "/bin/zsh"
 	},
 
+	"settings": {
+		"[terraform]": {
+			"editor.formatOnSave": true
+		}
+	},	
+
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"hashicorp.terraform",

--- a/server/aws/kms.tf
+++ b/server/aws/kms.tf
@@ -46,6 +46,11 @@ resource "aws_kms_key" "cw" {
 EOF
 }
 
+resource "aws_kms_alias" "cloudwatch" {
+  name          = "alias/cloudwatch"
+  target_key_id = aws_kms_key.cw.key_id
+}
+
 resource "aws_kms_key" "cw_us_east" {
   provider = aws.us-east-1
 
@@ -93,4 +98,11 @@ resource "aws_kms_key" "cw_us_east" {
   ]
 }
 EOF
+}
+
+resource "aws_kms_alias" "cloudwatch_us_east" {
+  provider = aws.us-east-1
+
+  name          = "alias/cloudwatch"
+  target_key_id = aws_kms_key.cw_us_east.key_id
 }


### PR DESCRIPTION
# Summary
This will be used for data lookups in the covid-alert-metrics-terraform project.

Also adds Terraform format on-save to the devcontainer.

# Expected changes
* 2 new KMS key aliases
* API gateway recreate

Related cds-snc/covid-alert-metrics-terraform#2