### PR TITLE
feat: bump threshold for save metrics duration alarm

### DIFF
--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -99,9 +99,9 @@ enable_test_tools = true
 raw_metrics_dynamodb_wcu_max       = 300
 aggregate_metrics_dynamodb_wcu_max = 300
 
-save_metrics_max_avg_duration      = 3000
+save_metrics_max_avg_duration      = 3010
 aggregate_metrics_max_avg_duration = 60000
-backoff_retry_max_avg_duration     = 3000
+backoff_retry_max_avg_duration     = 3010
 
 ###
 # Create CSV Lambda Variables

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -99,9 +99,9 @@ enable_test_tools = true
 raw_metrics_dynamodb_wcu_max       = 300
 aggregate_metrics_dynamodb_wcu_max = 300
 
-save_metrics_max_avg_duration      = 3010
+save_metrics_max_avg_duration      = 10000
 aggregate_metrics_max_avg_duration = 60000
-backoff_retry_max_avg_duration     = 3010
+backoff_retry_max_avg_duration     = 10000
 
 ###
 # Create CSV Lambda Variables


### PR DESCRIPTION
# Summary
We've seen a number of alerts over the past week around 3.001 and 3.002 seconds so this should help take down the noise.

# Expected change
* Recreate `aws_cloudwatch_metric_alarm.save_metrics_average_duration` alarm with `10000` threshold.
