### PR TITLE
fix: match API gateway account name to PROD

### DIFF
--- a/server/aws/mc-api-gateway.tf
+++ b/server/aws/mc-api-gateway.tf
@@ -146,7 +146,7 @@ resource "aws_api_gateway_usage_plan_key" "main" {
   usage_plan_id = aws_api_gateway_usage_plan.metrics_usage_plan.id
 }
 
-resource "aws_api_gateway_account" "demo" {
+resource "aws_api_gateway_account" "main" {
   cloudwatch_role_arn = aws_iam_role.api_gatway_cloudwatch_role.arn
 }
 


### PR DESCRIPTION
Match the API gateway account name resource name to PROD.  The state move was done locally with:
```terraform
terraform state mv aws_api_gateway_account.demo aws_api_gateway_account.main
```

# Expected changes
* Only the normal API gateway deployment and stage.

Fixes #184 
