### PR TITLE
fix: increase nofile ulimits for ECS retrieval task

### DIFF
--- a/server/aws/task-definitions/covidshield_key_retrieval.json
+++ b/server/aws/task-definitions/covidshield_key_retrieval.json
@@ -12,6 +12,13 @@
           "drop": ["ALL"]
         }
       },
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 65535,
+          "hardLimit": 65535
+        }
+      ],
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/server/aws/task-definitions/covidshield_key_retrieval.json
+++ b/server/aws/task-definitions/covidshield_key_retrieval.json
@@ -7,18 +7,18 @@
           "containerPort": 8001
         }
       ],
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 1000000,
+          "hardLimit": 1000000
+        }
+      ],
       "linuxParameters": {
         "capabilities": {
           "drop": ["ALL"]
         }
       },
-      "ulimits": [
-        {
-          "name": "nofile",
-          "softLimit": 65535,
-          "hardLimit": 65535
-        }
-      ],
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {


### PR DESCRIPTION
# Summary
This increases the open file limit to 65,535 to deal with the
increased time it's taking the key retrieval service to generate
TEK bundles.

By default ECS tasks have a soft limit of 1,024 open files.

# Related
cds-snc/covid-alert-server-production-terraform#120