### PR TITLE
feat: key retrieval use RDS read-only endpoint

### DIFF
--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -37,7 +37,7 @@ data "template_file" "covidshield_key_retrieval_task" {
     retrieve_hmac_key     = aws_secretsmanager_secret_version.key_retrieval_env_hmac_key.arn
     key_claim_token       = aws_secretsmanager_secret_version.key_submission_env_key_claim_token.arn
     ecdsa_key             = aws_secretsmanager_secret_version.key_retrieval_env_ecdsa_key.arn
-    database_url          = aws_secretsmanager_secret_version.server_database_url.arn
+    database_url          = aws_secretsmanager_secret_version.server_database_read_only_url.arn
     metric_provider       = var.metric_provider
     tracer_provider       = var.tracer_provider
     env                   = var.environment

--- a/server/aws/secrets.tf
+++ b/server/aws/secrets.tf
@@ -7,6 +7,15 @@ resource "aws_secretsmanager_secret_version" "server_database_url" {
   secret_string = "${var.rds_server_db_user}:${var.rds_server_db_password}@tcp(${aws_rds_cluster.covidshield_server.endpoint})/${var.rds_server_db_name}"
 }
 
+resource "aws_secretsmanager_secret" "server_database_read_only_url" {
+  name = "server-database-read-only-url-${random_string.random.result}"
+}
+
+resource "aws_secretsmanager_secret_version" "server_database_read_only_url" {
+  secret_id     = aws_secretsmanager_secret.server_database_read_only_url.id
+  secret_string = "${var.rds_server_db_user}:${var.rds_server_db_password}@tcp(${aws_rds_cluster.covidshield_server.reader_endpoint})/${var.rds_server_db_name}"
+}
+
 ###
 # AWS Secret Manager - Key Retrieval
 ###


### PR DESCRIPTION
# Summary
This updates the key retrieval ECS task to use the RDS cluster's
read-only endpoint now that cds-snc/covid-alert-server#461 has
moved all DB write operations to the key submission task.

# Related
cds-snc/covid-alert-server-production-terraform#120