### PR TITLE
fix: allow key retrieval task to access DB secret

### DIFF
--- a/server/aws/iam.tf
+++ b/server/aws/iam.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "covidshield_secrets_manager_key_retrieval" {
       aws_secretsmanager_secret.key_submission_env_key_claim_token.arn,
       aws_secretsmanager_secret.key_retrieval_env_hmac_key.arn,
       aws_secretsmanager_secret.key_retrieval_env_ecdsa_key.arn,
-      aws_secretsmanager_secret.server_database_url.arn,
+      aws_secretsmanager_secret.server_database_read_only_url.arn,
       aws_secretsmanager_secret.key_submission_metrics_password.arn
     ]
   }


### PR DESCRIPTION
# Summary
Gives the ECS key retrieval task access to the DB read-only URL secret.

# Related
#244 
cds-snc/covid-alert-server-production-terraform#120